### PR TITLE
fix(ui): tag modal close triggered back action Fixes #54

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -74,6 +74,11 @@ const MediaApp = {
         });
 
         window.addEventListener('popstate', (e) => {
+            // If HistoryManager is handling an overlay close, don't reload the directory
+            if (typeof HistoryManager !== 'undefined' && HistoryManager.isHandlingPopState) {
+                return;
+            }
+
             const path = e.state?.path || '';
             this.state.currentPath = path;
             this.state.currentPage = 1;

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -275,10 +275,11 @@ const Lightbox = {
     },
 
     closeWithHistory() {
-        this.close();
         if (typeof HistoryManager !== 'undefined' && HistoryManager.hasState('lightbox')) {
-            HistoryManager.removeState('lightbox');
+            // Let handlePopState close it
             history.back();
+        } else {
+            this.close();
         }
     },
 

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -659,10 +659,11 @@ const Player = {
     },
 
     closeWithHistory() {
-        this.close();
         if (typeof HistoryManager !== 'undefined' && HistoryManager.hasState('player')) {
-            HistoryManager.removeState('player');
+            // Let handlePopState close it
             history.back();
+        } else {
+            this.close();
         }
     },
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -453,10 +453,11 @@ const Search = {
     },
 
     hideResultsWithHistory() {
-        this.hideResults();
         if (HistoryManager.hasState('search')) {
-            HistoryManager.removeState('search');
+            // Let handlePopState close it
             history.back();
+        } else {
+            this.hideResults();
         }
     },
 

--- a/static/js/tags.js
+++ b/static/js/tags.js
@@ -22,7 +22,9 @@ const Tags = {
 
     bindEvents() {
         if (this.elements.tagModalClose) {
-            this.elements.tagModalClose.addEventListener('click', () => this.closeModalWithHistory());
+            this.elements.tagModalClose.addEventListener('click', () =>
+                this.closeModalWithHistory()
+            );
         }
 
         if (this.elements.tagModal) {
@@ -77,7 +79,7 @@ const Tags = {
 
         this.elements.tagModal.classList.remove('hidden');
         this.elements.tagInput.focus();
-        
+
         // Push history state for back button support
         HistoryManager.pushState('tag-modal');
     },
@@ -90,15 +92,17 @@ const Tags = {
         this.currentName = null;
     },
 
-    // Add new method for UI-triggered close:
+    // Called when user clicks X or clicks outside
     closeModalWithHistory() {
-        this.closeModal();
         if (HistoryManager.hasState('tag-modal')) {
-            HistoryManager.removeState('tag-modal');
+            // Don't close here - let handlePopState do it
+            // This ensures proper sequencing
             history.back();
+        } else {
+            // No history state, just close directly
+            this.closeModal();
         }
     },
-
 
     async loadFileTags(path) {
         try {
@@ -120,7 +124,7 @@ const Tags = {
             return;
         }
 
-        tags.forEach(tag => {
+        tags.forEach((tag) => {
             const tagEl = document.createElement('span');
             tagEl.className = 'tag-chip';
             tagEl.innerHTML = `
@@ -145,23 +149,27 @@ const Tags = {
         }
 
         // Filter existing tags that match
-        const matches = this.allTags.filter(tag => 
-            tag.name.toLowerCase().includes(query)
-        ).slice(0, 5);
+        const matches = this.allTags
+            .filter((tag) => tag.name.toLowerCase().includes(query))
+            .slice(0, 5);
 
         if (matches.length === 0) {
             this.elements.tagSuggestions.classList.add('hidden');
             return;
         }
 
-        this.elements.tagSuggestions.innerHTML = matches.map(tag => `
+        this.elements.tagSuggestions.innerHTML = matches
+            .map(
+                (tag) => `
             <div class="tag-suggestion" data-tag="${this.escapeHtml(tag.name)}">
                 ${this.highlightMatch(tag.name, query)}
                 <span class="tag-count">(${tag.itemCount})</span>
             </div>
-        `).join('');
+        `
+            )
+            .join('');
 
-        this.elements.tagSuggestions.querySelectorAll('.tag-suggestion').forEach(el => {
+        this.elements.tagSuggestions.querySelectorAll('.tag-suggestion').forEach((el) => {
             el.addEventListener('click', () => {
                 this.elements.tagInput.value = el.dataset.tag;
                 this.addTagFromInput();
@@ -176,9 +184,13 @@ const Tags = {
         const idx = lowerText.indexOf(query);
         if (idx === -1) return this.escapeHtml(text);
 
-        return this.escapeHtml(text.substring(0, idx)) +
-            '<mark>' + this.escapeHtml(text.substring(idx, idx + query.length)) + '</mark>' +
-            this.escapeHtml(text.substring(idx + query.length));
+        return (
+            this.escapeHtml(text.substring(0, idx)) +
+            '<mark>' +
+            this.escapeHtml(text.substring(idx, idx + query.length)) +
+            '</mark>' +
+            this.escapeHtml(text.substring(idx + query.length))
+        );
     },
 
     async addTagFromInput() {
@@ -238,15 +250,17 @@ const Tags = {
 
     updateGalleryItemTags(path) {
         // Update tags display on gallery items if visible
-        document.querySelectorAll(`.gallery-item[data-path="${CSS.escape(path)}"]`).forEach(item => {
-            // Trigger a refresh of the item's tags display
-            const tagsContainer = item.querySelector('.gallery-item-tags');
-            if (tagsContainer) {
-                this.loadFileTags(path).then(tags => {
-                    // Tags will be refreshed on next directory load
-                });
-            }
-        });
+        document
+            .querySelectorAll(`.gallery-item[data-path="${CSS.escape(path)}"]`)
+            .forEach((item) => {
+                // Trigger a refresh of the item's tags display
+                const tagsContainer = item.querySelector('.gallery-item-tags');
+                if (tagsContainer) {
+                    this.loadFileTags(path).then((tags) => {
+                        // Tags will be refreshed on next directory load
+                    });
+                }
+            });
     },
 
     // Search by tag
@@ -269,7 +283,7 @@ const Tags = {
         const moreCount = tags.length - 3;
 
         let html = '<div class="gallery-item-tags">';
-        displayTags.forEach(tag => {
+        displayTags.forEach((tag) => {
             html += `<span class="item-tag">${this.escapeHtml(tag)}</span>`;
         });
         if (moreCount > 0) {


### PR DESCRIPTION
## Description

When closing the tags modal, the browser fired a "back" action dropping the user back to the root directory.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Other: _____

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
  - Example: `feat(api): add video streaming endpoint`
  - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally

## Related Issues

<!-- Link related issues here -->

Closes #54 
Related to #

## Additional Notes

<!-- Any additional information -->
