### PR TITLE
fix(ui): tab key on new password selects eye icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - WebAuthN cleanup doesn't try to happen if it's not enabled ([#120](https://github.com/djryanj/media-viewer/issues/120))
 - Entering selection mode on mobile performance enhancements ([#79](https://github.com/djryanj/media-viewer/issues/79))
+- On initial password creation, tab order selected the "eye" icons instead of skipping to the next input box ([#127](https://github.com/djryanj/media-viewer/issues/127))
+- Eye icons were not rendering properly and they were being selected as with the above in the password change modal ([#127](https://github.com/djryanj/media-viewer/issues/127))
+- Dockerfile issues with cross compilation as a result of moving to VIPS package ([#117](https://github.com/djryanj/media-viewer/issues/117))
 
 ### Performance
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3078,6 +3078,59 @@ select:focus {
     max-width: 400px;
 }
 
+/* Password input with toggle button */
+.password-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.password-input-wrapper input {
+    width: 100%;
+    padding-right: 3rem; /* Make room for the toggle button */
+}
+
+.password-toggle {
+    position: absolute;
+    right: 0.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0.375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition:
+        color var(--transition),
+        background var(--transition);
+    width: 32px;
+    height: 32px;
+}
+
+.password-toggle:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.password-toggle:focus {
+    outline: none;
+    color: var(--border-focus);
+}
+
+.password-toggle i,
+.password-toggle svg {
+    width: 20px;
+    height: 20px;
+}
+
+.password-toggle .hidden {
+    display: none !important;
+}
+
 #password-form .form-group {
     margin-bottom: 1rem;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -360,20 +360,11 @@
                                     <button
                                         type="button"
                                         class="password-toggle"
+                                        tabindex="-1"
                                         aria-label="Toggle password visibility"
                                     >
-                                        <svg class="eye-open" viewBox="0 0 24 24">
-                                            <path
-                                                d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"
-                                            />
-                                            <circle cx="12" cy="12" r="3" />
-                                        </svg>
-                                        <svg class="eye-closed hidden" viewBox="0 0 24 24">
-                                            <path
-                                                d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"
-                                            />
-                                            <line x1="1" y1="1" x2="23" y2="23" />
-                                        </svg>
+                                        <i data-lucide="eye" class="eye-open"></i>
+                                        <i data-lucide="eye-off" class="eye-closed hidden"></i>
                                     </button>
                                 </div>
                             </div>
@@ -392,20 +383,11 @@
                                     <button
                                         type="button"
                                         class="password-toggle"
+                                        tabindex="-1"
                                         aria-label="Toggle password visibility"
                                     >
-                                        <svg class="eye-open" viewBox="0 0 24 24">
-                                            <path
-                                                d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"
-                                            />
-                                            <circle cx="12" cy="12" r="3" />
-                                        </svg>
-                                        <svg class="eye-closed hidden" viewBox="0 0 24 24">
-                                            <path
-                                                d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"
-                                            />
-                                            <line x1="1" y1="1" x2="23" y2="23" />
-                                        </svg>
+                                        <i data-lucide="eye" class="eye-open"></i>
+                                        <i data-lucide="eye-off" class="eye-closed hidden"></i>
                                     </button>
                                 </div>
                                 <span class="hint">At least 6 characters</span>
@@ -425,20 +407,11 @@
                                     <button
                                         type="button"
                                         class="password-toggle"
+                                        tabindex="-1"
                                         aria-label="Toggle password visibility"
                                     >
-                                        <svg class="eye-open" viewBox="0 0 24 24">
-                                            <path
-                                                d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"
-                                            />
-                                            <circle cx="12" cy="12" r="3" />
-                                        </svg>
-                                        <svg class="eye-closed hidden" viewBox="0 0 24 24">
-                                            <path
-                                                d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"
-                                            />
-                                            <line x1="1" y1="1" x2="23" y2="23" />
-                                        </svg>
+                                        <i data-lucide="eye" class="eye-open"></i>
+                                        <i data-lucide="eye-off" class="eye-closed hidden"></i>
                                     </button>
                                 </div>
                             </div>

--- a/static/login.html
+++ b/static/login.html
@@ -49,6 +49,7 @@
                             <button
                                 type="button"
                                 class="password-toggle"
+                                tabindex="-1"
                                 aria-label="Show password"
                             >
                                 <i data-lucide="eye" class="eye-open"></i>
@@ -89,6 +90,7 @@
                             <button
                                 type="button"
                                 class="password-toggle"
+                                tabindex="-1"
                                 aria-label="Show password"
                             >
                                 <i data-lucide="eye" class="eye-open"></i>
@@ -113,6 +115,7 @@
                             <button
                                 type="button"
                                 class="password-toggle"
+                                tabindex="-1"
                                 aria-label="Show password"
                             >
                                 <i data-lucide="eye" class="eye-open"></i>


### PR DESCRIPTION
Fixes #127

## Description

Password modal and initial password creation dialog boxes had incorrect tab order and/or eye icons show/hide functionality was broken

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Other: _____

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
  - Example: `feat(api): add video streaming endpoint`
  - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally

## Related Issues

<!-- Link related issues here -->

Closes #172
Related to #

## Additional Notes

<!-- Any additional information -->
