### PR TITLE
fix(db): Database migration doesn't work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [0.7.1] - February 3, 2026
+
+### Fixed
+
+- **Database Migration Error** - Fixed SQLite error when migrating to add `content_updated_at` column
+    - SQLite's `ALTER TABLE ADD COLUMN` doesn't support expressions in DEFAULT clause
+    - Changed from `DEFAULT (strftime('%s', 'now'))` to `DEFAULT 0` with immediate UPDATE
+    - Migration now succeeds on existing databases without "Cannot add a column with non-constant default" error
+
 ## [0.7.0] - February 3, 2026
 
 ### Added

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -218,9 +218,9 @@ func (d *Database) runMigrations(ctx context.Context) error {
 	if !columnExists {
 		logging.Info("Migrating database: adding content_updated_at column to files table")
 
-		// Add the column with default value from updated_at
+		// Add the column with a simple default (SQLite doesn't allow expressions in ALTER TABLE ADD COLUMN DEFAULT)
 		_, err = d.db.ExecContext(ctx, `
-			ALTER TABLE files ADD COLUMN content_updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+			ALTER TABLE files ADD COLUMN content_updated_at INTEGER NOT NULL DEFAULT 0
 		`)
 		if err != nil {
 			return fmt.Errorf("failed to add content_updated_at column: %w", err)
@@ -228,7 +228,7 @@ func (d *Database) runMigrations(ctx context.Context) error {
 
 		// Initialize content_updated_at from updated_at for existing records
 		_, err = d.db.ExecContext(ctx, `
-			UPDATE files SET content_updated_at = updated_at WHERE content_updated_at IS NULL OR content_updated_at = 0
+			UPDATE files SET content_updated_at = updated_at
 		`)
 		if err != nil {
 			return fmt.Errorf("failed to initialize content_updated_at values: %w", err)


### PR DESCRIPTION
Fixes #129

## Description

- **Database Migration Error** - Fixed SQLite error when migrating to add `content_updated_at` column
    - SQLite's `ALTER TABLE ADD COLUMN` doesn't support expressions in DEFAULT clause
    - Changed from `DEFAULT (strftime('%s', 'now'))` to `DEFAULT 0` with immediate UPDATE
    - Migration now succeeds on existing databases without "Cannot add a column with non-constant default" erro

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)

## Component

<!-- Which component does this PR affect? -->

- [X] Database
- [ ] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Other: _____

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
  - Example: `feat(api): add video streaming endpoint`
  - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally

## Related Issues

<!-- Link related issues here -->

Closes #129 
Related to #

## Additional Notes

<!-- Any additional information -->
