### PR TITLE
docs: resetpw command has incorrect help text

### DIFF
--- a/cmd/resetpw/doc.go
+++ b/cmd/resetpw/doc.go
@@ -1,17 +1,31 @@
-// Command resetpw provides a CLI utility for user management in the
+// Command resetpw provides a CLI utility for password management in the
 // media viewer application.
 //
 // It supports the following operations:
-//   - reset: Reset a user's password
-//   - create: Create a new user account
-//   - list: List all user accounts
-//   - delete: Delete a user account
+//   - reset: Reset the user's password (requires existing password setup)
+//   - status: Check if a password is configured
 //
 // Usage:
 //
 //	resetpw <command>
 //
+// Commands:
+//
+//	reset   Reset the password for the configured user account.
+//	        This requires that a password has already been set up via
+//	        the web interface. All existing sessions will be invalidated.
+//
+//	status  Display whether a password is configured. If no password
+//	        exists, initial setup must be done via the web interface.
+//
 // Environment:
 //
 //	DATABASE_DIR - Path to database directory (default: /database)
+//
+// Notes:
+//
+// The media viewer application uses a single-user authentication model.
+// Initial password setup must be performed through the web interface.
+// This utility is only for resetting an existing password or checking
+// configuration status.
 package main

--- a/cmd/resetpw/main.go
+++ b/cmd/resetpw/main.go
@@ -80,7 +80,7 @@ func main() {
 func printUsage() {
 	fmt.Println("Media Viewer Password Management")
 	fmt.Println("")
-	fmt.Println("Usage: usermgmt <command>")
+	fmt.Println("Usage: resetpw <command>")
 	fmt.Println("")
 	fmt.Println("Commands:")
 	fmt.Println("  reset   - Reset the password")


### PR DESCRIPTION
Fixes #143

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [X] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [ ] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [X] Documentation
- [X] Other: resetpw utility

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
  - Example: `feat(api): add video streaming endpoint`
  - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
