### PR TITLE
fix: video player: next/play/pause buttons should be centered in the center third of the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [0.11.2] - Unreleased
+
+### Changed
+
+- **Video Player Controls Layout**: Improved video player control button positioning to center all navigation controls together. Previous, Play/Pause, and Next buttons now appear grouped in the center third of the video instead of being spread across the edges. This creates a more cohesive control layout that's easier to use. Also enabled navigation buttons in the lightbox video player, allowing users to navigate between media items directly from the video overlay without closing the lightbox. ([#211](https://github.com/djryanj/media-viewer/issues/211))
+
 ## [0.11.1] - 2026-02-09
 
 ### Changed

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2671,33 +2671,8 @@ select:focus {
     height: 20px !important;
 }
 
-.video-prev,
-.video-next {
-    position: absolute;
-}
-
-.video-prev {
-    left: 2rem;
-}
-
-.video-next {
-    right: 2rem;
-}
-
-.player-modal.theater-mode .video-next {
-    right: 5rem;
-}
-
 /* Mobile portrait - reduce button size and adjust spacing */
 @media (max-width: 767px) and (orientation: portrait) {
-    .video-prev {
-        left: 0.5rem;
-    }
-
-    .video-next {
-        right: 0.5rem;
-    }
-
     .video-control-btn {
         width: 50px;
         height: 50px;
@@ -2713,10 +2688,6 @@ select:focus {
         top: auto;
         bottom: 7rem;
         transform: none;
-    }
-
-    .player-modal.theater-mode .video-next {
-        right: 0.5rem;
     }
 
     /* When playlist is visible, move toggle with it */
@@ -3272,14 +3243,6 @@ select:focus {
 .player-modal.landscape-mode .video-control-btn {
     width: 50px;
     height: 50px;
-}
-
-.player-modal.landscape-mode .video-prev {
-    left: 1rem;
-}
-
-.player-modal.landscape-mode .video-next {
-    right: 4rem;
 }
 
 .player-modal.landscape-mode .video-controls-bottom {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -1327,12 +1327,14 @@ const Lightbox = {
             this.videoPlayer = null;
         }
 
-        // Create new VideoPlayer instance
+        // Create new VideoPlayer instance with navigation
         if (typeof VideoPlayer !== 'undefined') {
             this.videoPlayer = new VideoPlayer({
                 video: this.elements.video,
                 container: this.elements.videoWrapper,
-                showNavigation: false,
+                showNavigation: true,
+                onPrevious: () => this.prev(),
+                onNext: () => this.next(),
             });
         }
     },

--- a/static/js/video-player.js
+++ b/static/js/video-player.js
@@ -67,11 +67,6 @@ class VideoPlayer {
         // Create controls overlay structure
         const controlsHTML = `
             <div class="video-controls" data-video-controls>
-                <!-- Center play/pause button -->
-                <button class="video-control-btn video-play-pause" data-play-pause-center title="Play/Pause">
-                    <i data-lucide="play"></i>
-                </button>
-
                 <!-- Previous/Next navigation buttons -->
                 ${
                     this.showNavigation
@@ -79,6 +74,18 @@ class VideoPlayer {
                 <button class="video-control-btn video-prev" data-video-prev title="Previous video">
                     <i data-lucide="skip-back"></i>
                 </button>
+                `
+                        : ''
+                }
+
+                <!-- Center play/pause button -->
+                <button class="video-control-btn video-play-pause" data-play-pause-center title="Play/Pause">
+                    <i data-lucide="play"></i>
+                </button>
+
+                ${
+                    this.showNavigation
+                        ? `
                 <button class="video-control-btn video-next" data-video-next title="Next video">
                     <i data-lucide="skip-forward"></i>
                 </button>


### PR DESCRIPTION
Fixes #211

## Description

Makes it a more natural layout. Also, in lightbox mode the prev/next buttons do appear in the video as well as having the chevrons on the side. This allows for multiple ways of doing the same thing and a consistent UX which I feel is appropriate.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Other: _____

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
  - Example: `feat(api): add video streaming endpoint`
  - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
