### PR TITLE
fix: Lightbox video: cannot use video progress bar since v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [0.11.4] - Unreleased
+
+### Fixed
+
+- **Video Player Controls**: Fixed video player scrub bar and navigation hotzones in lightbox on mobile devices. After the recent hotzone fix, the video progress bar became unusable as swipe gestures would take over when attempting to scrub through video. Adjusted z-index hierarchy to ensure video controls (z-index: 20) are above hotzones (z-index: 15), which are above the video wrapper (z-index: 10). Added explicit `pointer-events: auto` to progress bar, progress container, and controls row elements to ensure touch events are captured by interactive controls. This maintains both working hotzones for navigation swipes and a fully functional video scrub bar on mobile. ([#225](https://github.com/djryanj/media-viewer/issues/225))
+
 ## [0.11.3] - 2026-02-09
 
 ### Fixed

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1907,7 +1907,7 @@ select:focus {
     cursor: pointer;
     opacity: 0;
     transition: opacity 0.2s ease;
-    z-index: 5;
+    z-index: 15;
     -webkit-tap-highlight-color: transparent;
     -webkit-mask-image: linear-gradient(
         to bottom,
@@ -2598,6 +2598,7 @@ select:focus {
     max-width: 100%;
     max-height: 100%;
     display: none;
+    z-index: 10;
 }
 
 /* Show video wrapper only in video mode */
@@ -2628,7 +2629,7 @@ select:focus {
     gap: 2rem;
     opacity: 0;
     transition: opacity 0.3s ease;
-    z-index: 15;
+    z-index: 20;
     pointer-events: none;
 }
 
@@ -2718,13 +2719,14 @@ select:focus {
     left: 0;
     right: 0;
     padding: 1rem;
-    z-index: 1;
+    z-index: 20;
 }
 
 .video-progress-container {
     width: 100%;
     padding: 0.5rem 0;
     cursor: pointer;
+    pointer-events: auto;
 }
 
 .video-progress-bar {
@@ -2734,6 +2736,7 @@ select:focus {
     border-radius: 2.5px;
     position: relative;
     overflow: visible;
+    pointer-events: auto;
 }
 
 .video-progress-bar:hover {
@@ -2788,6 +2791,7 @@ select:focus {
     align-items: center;
     gap: 0.75rem;
     margin-top: 0.5rem;
+    pointer-events: auto;
 }
 
 .video-time {


### PR DESCRIPTION
Fixes #225

## Description

Fixes hotzones and progress bar not being properly usable

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Other: _____

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
  - Example: `feat(api): add video streaming endpoint`
  - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
