### PR TITLE
fix: transcoder not returning errors to client properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [0.12.2] - Unreleased
+
+### Fixed
+
+- **Video Dimension Compatibility**: Fixed transcoding failures for videos with unusual dimensions. Some older videos (particularly FLV files and certain codecs) have dimensions that aren't compatible with modern web video formats, causing "height not divisible by 2" errors and preventing playback. The transcoder now automatically adjusts video dimensions during conversion to ensure compatibility, allowing these videos to play successfully in your browser. ([#244](https://github.com/djryanj/media-viewer/issues/244))
+
+- **Transcoding Error Display**: Fixed transcoding errors not being displayed to users. When video transcoding failed (due to corrupted files, unsupported formats, or other issues), the error was only logged on the server with no feedback shown in the browser. Users would see indefinite loading spinners without knowing what went wrong. The system now properly communicates transcoding failures to your browser, displaying user-friendly error messages like "Video transcoding failed" so you know when a video can't be played. ([#244](https://github.com/djryanj/media-viewer/issues/244))
+
 ## [0.12.1] - 2026-02-10
 
 ### Fixed

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -1739,7 +1739,7 @@ const Lightbox = {
             console.error('Error loading video:', e);
             this.hideLoading();
 
-            // Check if this is an auth error
+            // Check if this is an auth error or other server error
             try {
                 const response = await fetchWithTimeout(videoUrl, {
                     method: 'HEAD',
@@ -1751,6 +1751,24 @@ const Lightbox = {
                         SessionManager.handleSessionExpired();
                     } else {
                         window.location.replace('/login.html');
+                    }
+                } else if (response.status === 500) {
+                    console.error('Lightbox: server error loading video');
+                    if (typeof Gallery !== 'undefined' && Gallery.showToast) {
+                        Gallery.showToast(
+                            'Failed to load video. The file may be corrupted or incompatible with transcoding.',
+                            'error',
+                            10000
+                        );
+                    }
+                } else if (response.status >= 400) {
+                    console.error('Lightbox: HTTP error', response.status);
+                    if (typeof Gallery !== 'undefined' && Gallery.showToast) {
+                        Gallery.showToast(
+                            `Failed to load video (Error ${response.status})`,
+                            'error',
+                            8000
+                        );
                     }
                 }
             } catch (err) {

--- a/static/js/playlist.js
+++ b/static/js/playlist.js
@@ -1056,7 +1056,7 @@ const Playlist = {
     },
 
     /**
-     * Check if a video load failure was due to authentication
+     * Check if a video load failure was due to authentication or other server errors
      * @param {string} videoUrl - The URL that failed to load
      */
     async checkVideoAuthError(videoUrl) {
@@ -1069,6 +1069,24 @@ const Playlist = {
                 } else {
                     this.close();
                     window.location.replace('/login.html');
+                }
+            } else if (response.status === 500) {
+                console.error('Player: server error loading video');
+                if (typeof Gallery !== 'undefined' && Gallery.showToast) {
+                    Gallery.showToast(
+                        'Failed to load video. The file may be corrupted or incompatible with transcoding.',
+                        'error',
+                        10000
+                    );
+                }
+            } else if (response.status >= 400) {
+                console.error('Player: HTTP error', response.status);
+                if (typeof Gallery !== 'undefined' && Gallery.showToast) {
+                    Gallery.showToast(
+                        `Failed to load video (Error ${response.status})`,
+                        'error',
+                        8000
+                    );
                 }
             }
         } catch (e) {


### PR DESCRIPTION
Fixes #244

## Description

Fixes an issue where video errors in the transcoder failed silently to the user. This implements error replies, but also specifically handles an error case which was causing the problem.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [X] API/Handlers
- [X] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Other: _____

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
  - Example: `feat(api): add video streaming endpoint`
  - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
