### PR TITLE
fix: thumbnail generation shouldn't try to run again if it's already running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Thumbnail Generation Reliability**: Fixed an issue where thumbnail generation could run multiple times simultaneously, causing thumbnails to be invalidated and regenerated unnecessarily. This could happen when the scheduled thumbnail generation triggered at the same time as indexing completed or when a manual rebuild was requested. The system now properly ensures only one thumbnail generation process runs at a time, preventing wasted resources and cache conflicts. ([#260](https://github.com/djryanj/media-viewer/issues/260))
+
 - **NVIDIA GPU Support in Docker**: Requires `Dockerfile.nvidia` (Debian-based) due to musl/glibc incompatibility. Alpine-based standard Dockerfile cannot load NVIDIA drivers even with NVIDIA Container Toolkit configured. Docker users need `--gpus all` flag with Debian image. ([#259](https://github.com/djryanj/media-viewer/issues/259)). New docker tags like `:latest-nvidia`, `:v1.0.0-nvidia`, `:v1.0-nvidia` now available.
 
 ## [0.13.0] - 2026-02-11

--- a/internal/media/thumbnail.go
+++ b/internal/media/thumbnail.go
@@ -1210,12 +1210,13 @@ func (t *ThumbnailGenerator) runGeneration(incremental bool) {
 		return
 	}
 
-	if t.isGenerating.Load() {
+	// Use CompareAndSwap to atomically check and set the flag
+	// This prevents race conditions where multiple goroutines could pass a Load() check
+	if !t.isGenerating.CompareAndSwap(false, true) {
 		logging.Info("Thumbnail generation already in progress, skipping")
 		return
 	}
 
-	t.isGenerating.Store(true)
 	defer t.isGenerating.Store(false)
 
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #260

## Description

Fixes an issue where the thumbnail generation would run more than once if it was already running.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [ ] Frontend/UI
- [ ] API/Handlers
- [X] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have run `make pr-check` and all checks passed
    - Lint fixes: ✓
    - Tests: ✓
    - Race detector: ✓

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
