### PR TITLE
fix: when shutting down in the middle of a gpu transcode, it falls back to cpu instead of shutting down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Thumbnail Generation Reliability**: Fixed an issue where thumbnail generation could run multiple times simultaneously, causing thumbnails to be invalidated and regenerated unnecessarily. This could happen when the scheduled thumbnail generation triggered at the same time as indexing completed or when a manual rebuild was requested. The system now properly ensures only one thumbnail generation process runs at a time, preventing wasted resources and cache conflicts. ([#260](https://github.com/djryanj/media-viewer/issues/260))
 
-- **NVIDIA GPU Support in Docker**: Requires `Dockerfile.nvidia` (Debian-based) due to musl/glibc incompatibility. Alpine-based standard Dockerfile cannot load NVIDIA drivers even with NVIDIA Container Toolkit configured. Docker users need `--gpus all` flag with Debian image. ([#259](https://github.com/djryanj/media-viewer/issues/259)). New docker tags like `:latest-nvidia`, `:v1.0.0-nvidia`, `:v1.0-nvidia` now available.
+- **GPU Transcoding During Shutdown**: Fixed GPU video transcoding unnecessarily retrying with CPU encoding when the application is shutting down. Previously, if a GPU transcode was interrupted during shutdown, it would detect the GPU failure and attempt to retry with CPU encoding, delaying the shutdown process. The system now properly detects when shutdown is in progress and cancels transcoding immediately without retrying. ([#258](https://github.com/djryanj/media-viewer/issues/258))
+
+- **NVIDIA GPU Support in Docker**: Requires `Dockerfile.nvidia` (Debian-based) due to musl/glibc incompatibility. Alpine-based standard Dockerfile cannot load NVIDIA drivers even with NVIDIA Container Toolkit configured. Docker users need `--gpus all` flag with Debian image. ([#259](https://github.com/djryanj/media-viewer/issues/259)). New docker tags like `:latest-nvidia`, `:v1.0.0-nvidia`, `:v1.0-nvidia` now available. ([#265](https://github.com/djryanj/media-viewer/issues/265))
 
 ## [0.13.0] - 2026-02-11
 


### PR DESCRIPTION
Fixes #258

## Description

Transcoder now properly shuts down when in the middle of a GPU and the container is requested to stop.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [ ] Frontend/UI
- [ ] API/Handlers
- [X] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have run `make pr-check` and all checks passed
    - Lint fixes: ✓
    - Tests: ✓
    - Race detector: ✓

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
