### PR TITLE
perf(database): database: use WAL mode rather than mutexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Click-drag to select multiple items extended to desktop.
     - Tags in the lightbox have been changed to a drawer system with better copy/paste functionality. [#327](https://github.com/djryanj/media-viewer/issues/327)
       The interface now much more closely resembles proven designs.
+- BREAKING: Database layer refactored for significantly improved performance and concurrency ([#338](https://github.com/djryanj/media-viewer/issues/338)
+    - Removed application-level sync.RWMutex from all database operations. SQLite WAL mode with busy_timeout now handles all read/write concurrency internally, eliminating unnecessary Go-level serialization that was blocking concurrent readers during writes.
+    - WAL mode and all SQLite PRAGMAs (synchronous, cache_size, temp_store, busy_timeout, mmap_size) moved from the connection string to a ConnectHook, ensuring consistent per-connection configuration across the pool.
+    - Introduced separate reader and writer connection pools. The writer pool is limited to a single connection (eliminating SQLITE_BUSY between writers entirely), while the reader pool allows up to 16 concurrent read connections under WAL mode.
+    - Introduced BatchInserter type for batch indexing operations. The upsert and delete prepared statements are now created once per batch and reused across all files, eliminating repeated query parsing during indexing.
+    - BeginBatch now returns a \*BatchInserter (breaking API change). UpsertFile and DeleteMissingFiles are now methods on BatchInserter rather than Database.
+    - Fixed N+1 query pattern in GetFilesByTag — per-row tag and favorite lookups replaced with scalar subqueries in the main SQL query.
+    - Benchmark results show 2× faster writes (UpsertFile), 11% faster directory listings, and up to 16% faster large read operations with many tags.
+
 - perf: optimizing some slow database queries [[#322](https://github.com/djryanj/media-viewer/issues/322)]. Performance analysis before/after:
   | Benchmark | Before (ns/op) | After (ns/op) | Change | Notes |
   | ---------------------------------------------- | -------------- | ------------- | -------- | ------------------------------------------ |

--- a/internal/database/auth.go
+++ b/internal/database/auth.go
@@ -34,7 +34,6 @@ type Session struct {
 // DefaultSessionDuration is the default session length if not configured.
 const DefaultSessionDuration = 5 * time.Minute
 
-// sessionDuration is the configured session duration (set via SetSessionDuration).
 var sessionDuration = DefaultSessionDuration
 
 // SetSessionDuration configures the session duration.
@@ -53,32 +52,26 @@ func GetSessionDuration() time.Duration {
 }
 
 // IsSetupComplete checks if initial setup has been completed.
-// This is more efficient than HasUsers() as it avoids COUNT(*) queries.
+// IsSetupComplete checks if initial setup has been completed.
 func (d *Database) IsSetupComplete(ctx context.Context) bool {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var setupComplete int
-	err := d.db.QueryRowContext(ctx, "SELECT COALESCE(MAX(setup_complete), 0) FROM users").Scan(&setupComplete)
+	err := d.reader.QueryRowContext(ctx, "SELECT COALESCE(MAX(setup_complete), 0) FROM users").Scan(&setupComplete)
 	if err != nil {
 		return false
 	}
 	return setupComplete == 1
 }
 
-// HasUsers checks if a user exists (single-user app).
+// HasUsers checks if a user exists.
 func (d *Database) HasUsers(ctx context.Context) bool {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var count int
-	err := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
+	err := d.reader.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
 	if err != nil {
 		return false
 	}
@@ -89,15 +82,12 @@ func (d *Database) HasUsers(ctx context.Context) bool {
 func (d *Database) CreateUser(ctx context.Context, password string) error {
 	done := observeQuery("create_user")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Check if a user already exists (single-user system)
+	// Check via reader (fast, no write lock needed)
 	var count int
-	err := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
+	err := d.reader.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
 	if err != nil {
 		err = fmt.Errorf("failed to check existing users: %w", err)
 		done(err)
@@ -109,7 +99,6 @@ func (d *Database) CreateUser(ctx context.Context, password string) error {
 		return err
 	}
 
-	// Hash the password
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		err = fmt.Errorf("failed to hash password: %w", err)
@@ -117,7 +106,7 @@ func (d *Database) CreateUser(ctx context.Context, password string) error {
 		return err
 	}
 
-	_, err = d.db.ExecContext(ctx,
+	_, err = d.writer.ExecContext(ctx,
 		"INSERT INTO users (password_hash, setup_complete) VALUES (?, 1)",
 		string(hash),
 	)
@@ -135,16 +124,13 @@ func (d *Database) CreateUser(ctx context.Context, password string) error {
 func (d *Database) ValidatePassword(ctx context.Context, password string) (*User, error) {
 	done := observeQuery("validate_password")
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var user User
 	var createdAt, updatedAt int64
 
-	err := d.db.QueryRowContext(ctx,
+	err := d.reader.QueryRowContext(ctx,
 		"SELECT id, password_hash, created_at, updated_at FROM users LIMIT 1",
 	).Scan(&user.ID, &user.PasswordHash, &createdAt, &updatedAt)
 
@@ -154,7 +140,6 @@ func (d *Database) ValidatePassword(ctx context.Context, password string) (*User
 		return nil, err
 	}
 
-	// Check password
 	if err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {
 		err = fmt.Errorf("invalid password")
 		done(err)
@@ -172,13 +157,9 @@ func (d *Database) ValidatePassword(ctx context.Context, password string) (*User
 func (d *Database) CreateSession(ctx context.Context, userID int64) (*Session, error) {
 	done := observeQuery("create_session")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Generate random token
 	tokenBytes := make([]byte, 32)
 	if _, err := rand.Read(tokenBytes); err != nil {
 		err = fmt.Errorf("failed to generate token: %w", err)
@@ -186,14 +167,13 @@ func (d *Database) CreateSession(ctx context.Context, userID int64) (*Session, e
 		return nil, err
 	}
 
-	// Hash the token for storage
 	hash := sha256.Sum256(tokenBytes)
 	tokenHash := hex.EncodeToString(hash[:])
 	token := hex.EncodeToString(tokenBytes)
 
 	expiresAt := time.Now().Add(sessionDuration)
 
-	result, err := d.db.ExecContext(ctx,
+	result, err := d.writer.ExecContext(ctx,
 		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
 		userID, tokenHash, expiresAt.Unix(),
 	)
@@ -205,14 +185,14 @@ func (d *Database) CreateSession(ctx context.Context, userID int64) (*Session, e
 
 	id, _ := result.LastInsertId()
 
-	//nolint:contextcheck // Metrics update uses background context for reliability
+	//nolint:contextcheck
 	d.updateActiveSessionsMetric()
 
 	done(nil)
 	return &Session{
 		ID:        id,
 		UserID:    userID,
-		Token:     token, // Return unhashed token to client
+		Token:     token,
 		ExpiresAt: expiresAt,
 		CreatedAt: time.Now(),
 	}, nil
@@ -222,13 +202,9 @@ func (d *Database) CreateSession(ctx context.Context, userID int64) (*Session, e
 func (d *Database) ValidateSession(ctx context.Context, token string) (*User, error) {
 	done := observeQuery("validate_session")
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Hash the token for lookup
 	tokenBytes, err := hex.DecodeString(token)
 	if err != nil {
 		err = fmt.Errorf("invalid token format")
@@ -241,7 +217,7 @@ func (d *Database) ValidateSession(ctx context.Context, token string) (*User, er
 	var userID int64
 	var expiresAt int64
 
-	err = d.db.QueryRowContext(ctx,
+	err = d.reader.QueryRowContext(ctx,
 		"SELECT user_id, expires_at FROM sessions WHERE token = ?",
 		tokenHash,
 	).Scan(&userID, &expiresAt)
@@ -252,10 +228,8 @@ func (d *Database) ValidateSession(ctx context.Context, token string) (*User, er
 		return nil, err
 	}
 
-	// Check expiration
 	if time.Now().Unix() > expiresAt {
-		// Clean up expired session in background
-		//nolint:contextcheck // Intentionally using background context for fire-and-forget cleanup
+		//nolint:contextcheck
 		go func() {
 			bgCtx, bgCancel := context.WithTimeout(context.Background(), defaultTimeout)
 			defer bgCancel()
@@ -268,10 +242,9 @@ func (d *Database) ValidateSession(ctx context.Context, token string) (*User, er
 		return nil, err
 	}
 
-	// Get user
 	var user User
 	var createdAtU, updatedAtU int64
-	err = d.db.QueryRowContext(ctx,
+	err = d.reader.QueryRowContext(ctx,
 		"SELECT id, created_at, updated_at FROM users WHERE id = ?",
 		userID,
 	).Scan(&user.ID, &createdAtU, &updatedAtU)
@@ -293,13 +266,9 @@ func (d *Database) ValidateSession(ctx context.Context, token string) (*User, er
 func (d *Database) ExtendSession(ctx context.Context, token string) error {
 	done := observeQuery("extend_session")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Hash the token for lookup
 	tokenBytes, err := hex.DecodeString(token)
 	if err != nil {
 		done(err)
@@ -310,7 +279,7 @@ func (d *Database) ExtendSession(ctx context.Context, token string) error {
 
 	newExpiresAt := time.Now().Add(sessionDuration)
 
-	result, err := d.db.ExecContext(ctx,
+	result, err := d.writer.ExecContext(ctx,
 		"UPDATE sessions SET expires_at = ? WHERE token = ? AND expires_at > ?",
 		newExpiresAt.Unix(), tokenHash, time.Now().Unix(),
 	)
@@ -331,15 +300,11 @@ func (d *Database) ExtendSession(ctx context.Context, token string) error {
 	return nil
 }
 
-// deleteSessionByHash removes a session by its hashed token.
 func (d *Database) deleteSessionByHash(ctx context.Context, tokenHash string) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	result, err := d.db.ExecContext(ctx, "DELETE FROM sessions WHERE token = ?", tokenHash)
+	result, err := d.writer.ExecContext(ctx, "DELETE FROM sessions WHERE token = ?", tokenHash)
 	if err != nil {
 		return err
 	}
@@ -352,7 +317,7 @@ func (d *Database) deleteSessionByHash(ctx context.Context, tokenHash string) er
 	return nil
 }
 
-// DeleteSession removes a session.
+// DeleteSession deletes a session by token.
 func (d *Database) DeleteSession(ctx context.Context, token string) error {
 	tokenBytes, err := hex.DecodeString(token)
 	if err != nil {
@@ -363,40 +328,34 @@ func (d *Database) DeleteSession(ctx context.Context, token string) error {
 
 	err = d.deleteSessionByHash(ctx, tokenHash)
 	if err == nil {
-		//nolint:contextcheck // Metrics update uses background context for reliability
+		//nolint:contextcheck
 		d.updateActiveSessionsMetric()
 	}
 	return err
 }
 
-// DeleteAllSessions removes all sessions (used when password is changed).
+// DeleteAllSessions removes all sessions from the database.
 func (d *Database) DeleteAllSessions(ctx context.Context) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(ctx, "DELETE FROM sessions")
+	_, err := d.writer.ExecContext(ctx, "DELETE FROM sessions")
 	return err
 }
 
-// CleanExpiredSessions removes all expired sessions.
+// CleanExpiredSessions removes expired sessions from the database.
 func (d *Database) CleanExpiredSessions(ctx context.Context) error {
 	done := observeQuery("clean_expired_sessions")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	result, err := d.db.ExecContext(ctx, "DELETE FROM sessions WHERE expires_at < ?", time.Now().Unix())
+	result, err := d.writer.ExecContext(ctx, "DELETE FROM sessions WHERE expires_at < ?", time.Now().Unix())
 	if err == nil {
 		if rows, _ := result.RowsAffected(); rows > 0 {
 			logging.Debug("Cleaned %d expired sessions", rows)
 		}
-		//nolint:contextcheck // Metrics update uses background context for reliability
+		//nolint:contextcheck
 		d.updateActiveSessionsMetric()
 	}
 	done(err)
@@ -406,9 +365,6 @@ func (d *Database) CleanExpiredSessions(ctx context.Context) error {
 // UpdatePassword updates the user's password and invalidates all sessions.
 func (d *Database) UpdatePassword(ctx context.Context, newPassword string) error {
 	done := observeQuery("update_password")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
@@ -420,8 +376,14 @@ func (d *Database) UpdatePassword(ctx context.Context, newPassword string) error
 		return err
 	}
 
-	// Update the single user's password
-	result, err := d.db.ExecContext(ctx,
+	tx, err := d.writer.BeginTx(ctx, nil)
+	if err != nil {
+		done(err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	result, err := tx.ExecContext(ctx,
 		"UPDATE users SET password_hash = ?, updated_at = strftime('%s', 'now')",
 		string(hash),
 	)
@@ -438,22 +400,26 @@ func (d *Database) UpdatePassword(ctx context.Context, newPassword string) error
 		return err
 	}
 
-	// Invalidate all sessions
-	if _, delErr := d.db.ExecContext(ctx, "DELETE FROM sessions"); delErr != nil {
+	if _, delErr := tx.ExecContext(ctx, "DELETE FROM sessions"); delErr != nil {
 		logging.Warn("failed to invalidate sessions: %v", delErr)
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		done(commitErr)
+		return fmt.Errorf("failed to commit password update: %w", commitErr)
 	}
 
 	done(nil)
 	return nil
 }
 
-// updateActiveSessionsMetric updates the active sessions gauge.
+// updateActiveSessionsMetric updates the active session metric.
 func (d *Database) updateActiveSessionsMetric() {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	var count int
-	err := d.db.QueryRowContext(ctx,
+	err := d.reader.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM sessions WHERE expires_at > ?",
 		time.Now().Unix(),
 	).Scan(&count)

--- a/internal/database/auth_integration_test.go
+++ b/internal/database/auth_integration_test.go
@@ -427,7 +427,7 @@ func TestCleanExpiredSessionsIntegration(t *testing.T) {
 
 	// Create an expired session by directly inserting into DB
 	expiredToken := "expired-token-12345678901234567890"
-	_, err := db.db.ExecContext(ctx, `
+	_, err := db.writer.ExecContext(ctx, `
 		INSERT INTO sessions (user_id, token, expires_at)
 		VALUES (?, ?, ?)
 	`, user.ID, expiredToken, time.Now().Add(-1*time.Hour).Unix())
@@ -545,7 +545,7 @@ func TestPasswordHashingIntegration(t *testing.T) {
 
 	// Query the database directly to verify password is hashed
 	var passwordHash string
-	err := db.db.QueryRowContext(ctx, "SELECT password_hash FROM users LIMIT 1").Scan(&passwordHash)
+	err := db.reader.QueryRowContext(ctx, "SELECT password_hash FROM users LIMIT 1").Scan(&passwordHash)
 	if err != nil {
 		t.Fatalf("Failed to query password hash: %v", err)
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -17,66 +17,72 @@ import (
 	"media-viewer/internal/metrics"
 )
 
-// Default timeout for database operations
 const defaultTimeout = 5 * time.Second
-
-// driverName is the custom SQLite driver name with mmap disabled.
-// Used only when mmap protection is requested.
-const driverName = "sqlite3_mmap_disabled"
-
-// standardDriverName is the default go-sqlite3 driver.
-const standardDriverName = "sqlite3"
-
-// unknownStr is a constant string to satisfy goconst
+const driverName = "sqlite3_custom"
 const unknownStr = "unknown"
 
-// registerOnce ensures the custom driver is registered exactly once.
 var registerOnce sync.Once
 
-// registerDriver registers our custom SQLite driver with mmap disabled.
-func registerDriver() {
+func registerDriver(opts *Options) {
 	registerOnce.Do(func() {
+		mmapDisabled := opts != nil && opts.MmapDisabled
+
 		sql.Register(driverName, &sqlite3.SQLiteDriver{
 			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-				_, err := conn.Exec("PRAGMA mmap_size = 0", nil)
-				return err
+				pragmas := []string{
+					"PRAGMA journal_mode=WAL",
+					"PRAGMA synchronous=NORMAL",
+					"PRAGMA cache_size=10000",
+					"PRAGMA temp_store=MEMORY",
+					"PRAGMA busy_timeout=5000",
+				}
+				if mmapDisabled {
+					pragmas = append(pragmas, "PRAGMA mmap_size=0")
+				}
+				for _, p := range pragmas {
+					if _, err := conn.Exec(p, nil); err != nil {
+						return fmt.Errorf("failed to exec %s: %w", p, err)
+					}
+				}
+				return nil
 			},
 		})
 	})
 }
 
-func init() {
-	registerDriver()
-}
-
-// getSlowQueryThreshold returns the threshold for logging slow queries.
-// Can be configured via SLOW_QUERY_THRESHOLD_MS environment variable.
 func getSlowQueryThreshold() float64 {
 	if thresholdStr := os.Getenv("SLOW_QUERY_THRESHOLD_MS"); thresholdStr != "" {
 		if threshold, err := strconv.ParseFloat(thresholdStr, 64); err == nil {
 			return threshold / 1000.0
 		}
 	}
-	return 0.1 // Default 100ms
+	return 0.1
+}
+
+// preparedStmts holds pre-compiled SQL statements for hot-path queries.
+// These are prepared once during initialization against the reader pool
+// and reused for every call, eliminating repeated query parsing.
+type preparedStmts struct {
+	getFileByPath       *sql.Stmt
+	isFavorite          *sql.Stmt
+	calcStats           *sql.Stmt
+	countDirItems       *sql.Stmt
+	countDirItemsFilter *sql.Stmt
 }
 
 // Database manages all database operations for the media viewer.
 type Database struct {
-	db           *sql.DB
+	reader       *sql.DB
+	writer       *sql.DB
 	dbPath       string
-	mu           sync.RWMutex
 	stats        IndexStats
 	statsMu      sync.RWMutex
-	txStart      time.Time
 	mmapDisabled bool
+	stmts        preparedStmts
 }
 
 // Options holds configuration options for database initialization.
 type Options struct {
-	// MmapDisabled disables memory-mapped I/O for SQLite.
-	// This prevents SIGBUS crashes on unreliable storage backends
-	// (e.g., Longhorn, NFS, network-attached volumes).
-	// Default: false (mmap enabled — standard SQLite behavior).
 	MmapDisabled bool
 }
 
@@ -89,18 +95,6 @@ type Info struct {
 	MmapWarning       string
 }
 
-// ---------------------------------------------------------------------------
-// observeQuery replaces the old recordQuery pattern with an ergonomic helper.
-//
-// Usage:
-//
-//	done := observeQuery("upsert_file")
-//	result, err := tx.ExecContext(ctx, query, args...)
-//	done(err)
-//
-// It records DBQueryTotal (counter), DBQueryDuration (histogram), and logs
-// slow queries — all in one place when done() is called.
-// ---------------------------------------------------------------------------
 func observeQuery(operation string) func(error) {
 	start := time.Now()
 	return func(err error) {
@@ -120,14 +114,6 @@ func observeQuery(operation string) func(error) {
 	}
 }
 
-// activeDriverName returns the SQLite driver name to use based on options.
-func activeDriverName(opts *Options) string {
-	if opts != nil && opts.MmapDisabled {
-		return driverName
-	}
-	return standardDriverName
-}
-
 // New creates a new Database instance and returns diagnostic info for logging.
 func New(ctx context.Context, dbPath string, opts *Options) (*Database, *Info, error) {
 	info := &Info{Path: dbPath}
@@ -136,8 +122,8 @@ func New(ctx context.Context, dbPath string, opts *Options) (*Database, *Info, e
 		info.PermissionWarning = err.Error()
 	}
 
-	// Determine which driver to use based on mmap configuration
-	driver := activeDriverName(opts)
+	registerDriver(opts)
+
 	isMmapDisabled := opts != nil && opts.MmapDisabled
 	if isMmapDisabled {
 		logging.Info("SQLite mmap disabled (SIGBUS protection active for unreliable storage)")
@@ -145,38 +131,72 @@ func New(ctx context.Context, dbPath string, opts *Options) (*Database, *Info, e
 		logging.Debug("SQLite mmap enabled (default — standard performance mode)")
 	}
 
-	connStr := fmt.Sprintf("%s?_journal_mode=WAL&_synchronous=NORMAL&_cache_size=10000&_temp_store=MEMORY&_busy_timeout=5000", dbPath)
-
-	db, err := sql.Open(driver, connStr)
+	writer, err := sql.Open(driverName, dbPath)
 	if err != nil {
-		return nil, info, fmt.Errorf("failed to open database: %w", err)
+		return nil, info, fmt.Errorf("failed to open writer database: %w", err)
 	}
+	writer.SetMaxOpenConns(1)
+	writer.SetMaxIdleConns(1)
+	writer.SetConnMaxLifetime(0)
+
+	reader, err := sql.Open(driverName, dbPath)
+	if err != nil {
+		if cerr := writer.Close(); cerr != nil {
+			logging.Warn("failed to close writer after reader open failure: %v", cerr)
+		}
+		return nil, info, fmt.Errorf("failed to open reader database: %w", err)
+	}
+	reader.SetMaxOpenConns(16)
+	reader.SetMaxIdleConns(8)
+	reader.SetConnMaxLifetime(time.Hour)
 
 	pingCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	if err := db.PingContext(pingCtx); err != nil {
-		if cerr := db.Close(); cerr != nil {
-			logging.Warn("failed to close db after ping failure: %v", cerr)
+	if err := writer.PingContext(pingCtx); err != nil {
+		if cerr := writer.Close(); cerr != nil {
+			logging.Warn("failed to close writer: %v", cerr)
 		}
-		return nil, info, fmt.Errorf("failed to connect to database: %w", err)
+		if cerr := reader.Close(); cerr != nil {
+			logging.Warn("failed to close reader: %v", cerr)
+		}
+		return nil, info, fmt.Errorf("failed to ping writer database: %w", err)
+	}
+	if err := reader.PingContext(pingCtx); err != nil {
+		if cerr := writer.Close(); cerr != nil {
+			logging.Warn("failed to close writer: %v", cerr)
+		}
+		if cerr := reader.Close(); cerr != nil {
+			logging.Warn("failed to close reader: %v", cerr)
+		}
+		return nil, info, fmt.Errorf("failed to ping reader database: %w", err)
 	}
 
-	db.SetMaxOpenConns(25)
-	db.SetMaxIdleConns(10)
-	db.SetConnMaxLifetime(time.Hour)
-
 	d := &Database{
-		db:           db,
+		reader:       reader,
+		writer:       writer,
 		dbPath:       dbPath,
 		mmapDisabled: isMmapDisabled,
 	}
 
 	if err := d.initialize(ctx); err != nil {
-		if cerr := db.Close(); cerr != nil {
-			logging.Warn("failed to close db after initialize failure: %v", cerr)
+		if cerr := writer.Close(); cerr != nil {
+			logging.Warn("failed to close writer: %v", cerr)
+		}
+		if cerr := reader.Close(); cerr != nil {
+			logging.Warn("failed to close reader: %v", cerr)
 		}
 		return nil, info, fmt.Errorf("failed to initialize database schema: %w", err)
+	}
+
+	if err := d.prepareStatements(ctx); err != nil {
+		if cerr := writer.Close(); cerr != nil {
+			logging.Warn("failed to close writer: %v", cerr)
+		}
+		if cerr := reader.Close(); cerr != nil {
+			logging.Warn("failed to close reader: %v", cerr)
+		}
+		return nil, info, fmt.Errorf("failed to prepare statements: %w", err)
 	}
 
 	version, mmapStatus, mmapWarning := d.getSQLiteDiagnostics(ctx)
@@ -187,16 +207,84 @@ func New(ctx context.Context, dbPath string, opts *Options) (*Database, *Info, e
 	return d, info, nil
 }
 
-// getSQLiteDiagnostics returns SQLite version, mmap status, and any mmap warnings.
+// prepareStatements pre-compiles frequently used queries against the reader pool.
+func (d *Database) prepareStatements(ctx context.Context) error {
+	var err error
+
+	d.stmts.getFileByPath, err = d.reader.PrepareContext(ctx, `
+		SELECT id, name, path, parent_path, type, size, mod_time, mime_type
+		FROM files WHERE path = ?
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare getFileByPath: %w", err)
+	}
+
+	d.stmts.isFavorite, err = d.reader.PrepareContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM favorites WHERE path = ?)",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare isFavorite: %w", err)
+	}
+
+	d.stmts.calcStats, err = d.reader.PrepareContext(ctx, `
+		SELECT
+			COALESCE(SUM(CASE WHEN type != 'folder' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN type = 'folder' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN type = 'image' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN type = 'video' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN type = 'playlist' THEN 1 ELSE 0 END), 0),
+			(SELECT COUNT(*) FROM favorites),
+			(SELECT COUNT(*) FROM tags)
+		FROM files
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare calcStats: %w", err)
+	}
+
+	d.stmts.countDirItems, err = d.reader.PrepareContext(ctx,
+		"SELECT COUNT(*) FROM files WHERE parent_path = ?",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare countDirItems: %w", err)
+	}
+
+	d.stmts.countDirItemsFilter, err = d.reader.PrepareContext(ctx,
+		"SELECT COUNT(*) FROM files WHERE parent_path = ? AND (type = 'folder' OR type = ?)",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare countDirItemsFilter: %w", err)
+	}
+
+	return nil
+}
+
+// closeStatements closes all prepared statements.
+func (d *Database) closeStatements() {
+	stmts := []*sql.Stmt{
+		d.stmts.getFileByPath,
+		d.stmts.isFavorite,
+		d.stmts.calcStats,
+		d.stmts.countDirItems,
+		d.stmts.countDirItemsFilter,
+	}
+	for _, s := range stmts {
+		if s != nil {
+			if cerr := s.Close(); cerr != nil {
+				logging.Warn("failed to close prepared statement: %v", cerr)
+			}
+		}
+	}
+}
+
 func (d *Database) getSQLiteDiagnostics(ctx context.Context) (version, mmapStatus, mmapWarning string) {
 	queryCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	if err := d.db.QueryRowContext(queryCtx, "SELECT sqlite_version()").Scan(&version); err != nil {
+	if err := d.reader.QueryRowContext(queryCtx, "SELECT sqlite_version()").Scan(&version); err != nil {
 		version = unknownStr
 	}
 
-	rows, err := d.db.QueryContext(queryCtx, "PRAGMA compile_options")
+	rows, err := d.reader.QueryContext(queryCtx, "PRAGMA compile_options")
 	if err == nil {
 		defer func() {
 			if cerr := rows.Close(); cerr != nil {
@@ -218,9 +306,8 @@ func (d *Database) getSQLiteDiagnostics(ctx context.Context) (version, mmapStatu
 	}
 
 	var mmapSize int64
-	if err := d.db.QueryRowContext(queryCtx, "PRAGMA mmap_size").Scan(&mmapSize); err == nil {
+	if err := d.reader.QueryRowContext(queryCtx, "PRAGMA mmap_size").Scan(&mmapSize); err == nil {
 		if d.mmapDisabled {
-			// We intended to disable mmap
 			if mmapSize != 0 {
 				mmapStatus = fmt.Sprintf("CRITICAL: mmap_size is %d but should be 0 — SIGBUS protection is NOT active!", mmapSize)
 				metrics.DBMmapStatus.Set(float64(mmapSize))
@@ -229,7 +316,6 @@ func (d *Database) getSQLiteDiagnostics(ctx context.Context) (version, mmapStatu
 				metrics.DBMmapStatus.Set(0)
 			}
 		} else {
-			// mmap is intentionally enabled (default)
 			mmapStatus = fmt.Sprintf("mmap_size = %d (standard mode — set DB_MMAP_DISABLED=true if on unreliable storage)", mmapSize)
 			metrics.DBMmapStatus.Set(float64(mmapSize))
 		}
@@ -299,7 +385,6 @@ func (d *Database) initialize(ctx context.Context) error {
 	done := observeQuery("initialize_schema")
 
 	schema := `
-	-- Main files table
 	CREATE TABLE IF NOT EXISTS files (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		name TEXT NOT NULL,
@@ -328,9 +413,7 @@ func (d *Database) initialize(ctx context.Context) error {
 	CREATE INDEX IF NOT EXISTS idx_files_parent_type_size ON files(parent_path, type, size);
 
 	CREATE INDEX IF NOT EXISTS idx_files_path_type ON files(path, type);
-
 	CREATE INDEX IF NOT EXISTS idx_files_type_path ON files(type, path);
-
 	CREATE INDEX IF NOT EXISTS idx_files_path ON files(path);
 
 	CREATE INDEX IF NOT EXISTS idx_files_media_directory_name ON files(
@@ -342,9 +425,6 @@ func (d *Database) initialize(ctx context.Context) error {
 		id, path, size, mime_type
 	);
 
-	-- Optimized for GetMediaInDirectory: covers the IN ('image','video') filter
-	-- with parent_path, and includes columns for all three sort options so SQLite
-	-- can satisfy ORDER BY directly from the index (for single-type scans).
 	CREATE INDEX IF NOT EXISTS idx_files_parent_media_name ON files(
 		parent_path, name COLLATE NOCASE
 	) WHERE type IN ('image', 'video');
@@ -356,7 +436,6 @@ func (d *Database) initialize(ctx context.Context) error {
 	CREATE INDEX IF NOT EXISTS idx_files_parent_media_size ON files(
 		parent_path, size
 	) WHERE type IN ('image', 'video');
-
 
 	CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
 		name,
@@ -436,7 +515,7 @@ func (d *Database) initialize(ctx context.Context) error {
 	);
 	`
 
-	_, err := d.db.ExecContext(ctx, schema)
+	_, err := d.writer.ExecContext(ctx, schema)
 	done(err)
 	if err != nil {
 		return err
@@ -445,11 +524,9 @@ func (d *Database) initialize(ctx context.Context) error {
 	return d.runMigrations(ctx)
 }
 
-// runMigrations applies database schema migrations
 func (d *Database) runMigrations(ctx context.Context) error {
-	// Migration 1: Add content_updated_at column if it doesn't exist
 	var columnExists bool
-	err := d.db.QueryRowContext(ctx, `
+	err := d.writer.QueryRowContext(ctx, `
 		SELECT COUNT(*) > 0
 		FROM pragma_table_info('files')
 		WHERE name='content_updated_at'
@@ -463,7 +540,7 @@ func (d *Database) runMigrations(ctx context.Context) error {
 		logging.Info("Migrating database: adding content_updated_at column to files table")
 
 		done := observeQuery("migrate_add_content_updated_at")
-		_, err = d.db.ExecContext(ctx, `
+		_, err = d.writer.ExecContext(ctx, `
 			ALTER TABLE files ADD COLUMN content_updated_at INTEGER NOT NULL DEFAULT 0
 		`)
 		done(err)
@@ -472,7 +549,7 @@ func (d *Database) runMigrations(ctx context.Context) error {
 		}
 
 		done = observeQuery("migrate_init_content_updated_at")
-		_, err = d.db.ExecContext(ctx, `
+		_, err = d.writer.ExecContext(ctx, `
 			UPDATE files SET content_updated_at = updated_at
 		`)
 		done(err)
@@ -483,9 +560,8 @@ func (d *Database) runMigrations(ctx context.Context) error {
 		logging.Info("Migration complete: content_updated_at column added and initialized")
 	}
 
-	// Migration 2: Add setup_complete column to users table if it doesn't exist
 	var setupCompleteExists bool
-	err = d.db.QueryRowContext(ctx, `
+	err = d.writer.QueryRowContext(ctx, `
 		SELECT COUNT(*) > 0
 		FROM pragma_table_info('users')
 		WHERE name='setup_complete'
@@ -499,7 +575,7 @@ func (d *Database) runMigrations(ctx context.Context) error {
 		logging.Info("Migrating database: adding setup_complete column to users table")
 
 		done := observeQuery("migrate_add_setup_complete")
-		_, err = d.db.ExecContext(ctx, `
+		_, err = d.writer.ExecContext(ctx, `
 			ALTER TABLE users ADD COLUMN setup_complete INTEGER NOT NULL DEFAULT 0
 		`)
 		done(err)
@@ -508,7 +584,7 @@ func (d *Database) runMigrations(ctx context.Context) error {
 		}
 
 		done = observeQuery("migrate_init_setup_complete")
-		_, err = d.db.ExecContext(ctx, `
+		_, err = d.writer.ExecContext(ctx, `
 			UPDATE users SET setup_complete = 1 WHERE id IS NOT NULL
 		`)
 		done(err)
@@ -522,62 +598,24 @@ func (d *Database) runMigrations(ctx context.Context) error {
 	return err
 }
 
-// Close closes the database connection.
+// Close closes prepared statements and both database connection pools.
 func (d *Database) Close() error {
-	return d.db.Close()
+	d.closeStatements()
+	rErr := d.reader.Close()
+	wErr := d.writer.Close()
+	return errors.Join(rErr, wErr)
 }
 
-// BeginBatch starts a transaction for batch operations.
-func (d *Database) BeginBatch(ctx context.Context) (*sql.Tx, error) {
-	d.mu.Lock()
-
-	done := observeQuery("begin_transaction")
-	tx, err := d.db.BeginTx(ctx, nil)
-	done(err)
-
-	if err != nil {
-		d.mu.Unlock()
-		return nil, err
-	}
-
-	d.txStart = time.Now()
-
-	return tx, nil
+// BatchInserter wraps a write transaction with pre-prepared statements
+// for efficient batch indexing operations.
+type BatchInserter struct {
+	tx        *sql.Tx
+	upsert    *sql.Stmt
+	del       *sql.Stmt
+	startTime time.Time
 }
 
-// EndBatch commits or rolls back a transaction.
-func (d *Database) EndBatch(tx *sql.Tx, err error) error {
-	defer d.mu.Unlock()
-
-	duration := time.Since(d.txStart).Seconds()
-
-	if err != nil {
-		metrics.DBTransactionDuration.WithLabelValues("rollback").Observe(duration)
-
-		done := observeQuery("rollback")
-		rbErr := tx.Rollback()
-		done(rbErr)
-
-		if rbErr != nil {
-			return errors.Join(err, fmt.Errorf("rollback also failed: %w", rbErr))
-		}
-		return err
-	}
-
-	metrics.DBTransactionDuration.WithLabelValues("commit").Observe(duration)
-
-	done := observeQuery("commit")
-	commitErr := tx.Commit()
-	done(commitErr)
-
-	return commitErr
-}
-
-// UpsertFile inserts or updates a file record within a transaction.
-func (d *Database) UpsertFile(ctx context.Context, tx *sql.Tx, file *MediaFile) error {
-	done := observeQuery("upsert_file")
-
-	query := `
+const upsertQuery = `
 	INSERT INTO files (name, path, parent_path, type, size, mod_time, mime_type, file_hash, updated_at, content_updated_at)
 	VALUES (?, ?, ?, ?, ?, ?, ?, ?, strftime('%s', 'now'), strftime('%s', 'now'))
 	ON CONFLICT(path) DO UPDATE SET
@@ -596,9 +634,61 @@ func (d *Database) UpsertFile(ctx context.Context, tx *sql.Tx, file *MediaFile) 
 			THEN strftime('%s', 'now')
 			ELSE COALESCE(files.content_updated_at, strftime('%s', 'now'))
 		END
-	`
+`
 
-	result, err := tx.ExecContext(ctx, query,
+const deleteQuery = `DELETE FROM files WHERE updated_at < ?`
+
+// BeginBatch starts a batch indexing transaction with pre-prepared statements.
+func (d *Database) BeginBatch(ctx context.Context) (*BatchInserter, error) {
+	done := observeQuery("begin_transaction")
+	tx, err := d.writer.BeginTx(ctx, nil)
+	done(err)
+	if err != nil {
+		return nil, err
+	}
+
+	upsertStmt, err := tx.PrepareContext(ctx, upsertQuery)
+	if err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil {
+			logging.Warn("failed to rollback transaction: %v", rbErr)
+		}
+		return nil, fmt.Errorf("prepare upsert: %w", err)
+	}
+
+	delStmt, err := tx.PrepareContext(ctx, deleteQuery)
+	if err != nil {
+		if cerr := upsertStmt.Close(); cerr != nil { //nolint:errcheck,sqlclosecheck // cleanup on prepare failure; stmt not returned
+			logging.Warn("failed to close upsert statement: %v", cerr)
+		}
+		if rbErr := tx.Rollback(); rbErr != nil {
+			logging.Warn("failed to rollback transaction: %v", rbErr)
+		}
+		return nil, fmt.Errorf("prepare delete: %w", err)
+	}
+
+	return &BatchInserter{
+		tx:        tx,
+		upsert:    upsertStmt,
+		del:       delStmt,
+		startTime: time.Now(),
+	}, nil
+}
+
+// Tx returns the underlying transaction for direct access.
+func (b *BatchInserter) Tx() *sql.Tx {
+	return b.tx
+}
+
+// StartTime returns the batch start time for external metrics.
+func (b *BatchInserter) StartTime() time.Time {
+	return b.startTime
+}
+
+// UpsertFile inserts or updates a file record using the pre-prepared statement.
+func (b *BatchInserter) UpsertFile(ctx context.Context, file *MediaFile) error {
+	done := observeQuery("upsert_file")
+
+	result, err := b.upsert.ExecContext(ctx,
 		file.Name,
 		file.Path,
 		file.ParentPath,
@@ -619,13 +709,10 @@ func (d *Database) UpsertFile(ctx context.Context, tx *sql.Tx, file *MediaFile) 
 }
 
 // DeleteMissingFiles removes files that weren't seen during indexing.
-func (d *Database) DeleteMissingFiles(ctx context.Context, tx *sql.Tx, cutoffTime time.Time) (int64, error) {
+func (b *BatchInserter) DeleteMissingFiles(ctx context.Context, cutoffTime time.Time) (int64, error) {
 	done := observeQuery("delete_missing_files")
 
-	result, err := tx.ExecContext(ctx,
-		"DELETE FROM files WHERE updated_at < ?",
-		cutoffTime.Unix(),
-	)
+	result, err := b.del.ExecContext(ctx, cutoffTime.Unix())
 	done(err)
 
 	if err != nil {
@@ -639,25 +726,50 @@ func (d *Database) DeleteMissingFiles(ctx context.Context, tx *sql.Tx, cutoffTim
 	return rowsAffected, err
 }
 
-// GetFileByPath retrieves a single file by path.
-func (d *Database) GetFileByPath(ctx context.Context, path string) (*MediaFile, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+// EndBatch closes prepared statements and commits or rolls back the transaction.
+func (d *Database) EndBatch(b *BatchInserter, err error) error {
+	if cerr := b.upsert.Close(); cerr != nil {
+		logging.Warn("failed to close upsert statement: %v", cerr)
+	}
+	if cerr := b.del.Close(); cerr != nil {
+		logging.Warn("failed to close delete statement: %v", cerr)
+	}
 
+	duration := time.Since(b.startTime).Seconds()
+
+	if err != nil {
+		metrics.DBTransactionDuration.WithLabelValues("rollback").Observe(duration)
+
+		done := observeQuery("rollback")
+		rbErr := b.tx.Rollback()
+		done(rbErr)
+
+		if rbErr != nil {
+			return errors.Join(err, fmt.Errorf("rollback also failed: %w", rbErr))
+		}
+		return err
+	}
+
+	metrics.DBTransactionDuration.WithLabelValues("commit").Observe(duration)
+
+	done := observeQuery("commit")
+	commitErr := b.tx.Commit()
+	done(commitErr)
+
+	return commitErr
+}
+
+// GetFileByPath retrieves a single file by path using a prepared statement.
+func (d *Database) GetFileByPath(ctx context.Context, path string) (*MediaFile, error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	done := observeQuery("get_file_by_path")
 
-	query := `
-	SELECT id, name, path, parent_path, type, size, mod_time, mime_type
-	FROM files WHERE path = ?
-	`
-
 	var file MediaFile
 	var modTime int64
 
-	err := d.db.QueryRowContext(ctx, query, path).Scan(
+	err := d.stmts.getFileByPath.QueryRowContext(ctx, path).Scan(
 		&file.ID, &file.Name, &file.Path, &file.ParentPath,
 		&file.Type, &file.Size, &modTime, &file.MimeType,
 	)
@@ -687,14 +799,11 @@ func (d *Database) GetStats() IndexStats {
 
 // RebuildFTS rebuilds the full-text search index.
 func (d *Database) RebuildFTS() error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	done := observeQuery("rebuild_fts")
-	_, err := d.db.ExecContext(ctx, "INSERT INTO files_fts(files_fts) VALUES('rebuild')")
+	_, err := d.writer.ExecContext(ctx, "INSERT INTO files_fts(files_fts) VALUES('rebuild')")
 	done(err)
 
 	return err
@@ -702,26 +811,23 @@ func (d *Database) RebuildFTS() error {
 
 // Vacuum optimizes the database.
 func (d *Database) Vacuum() error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	done := observeQuery("vacuum")
-	_, err := d.db.ExecContext(ctx, "VACUUM")
+	_, err := d.writer.ExecContext(ctx, "VACUUM")
 	done(err)
 
 	return err
 }
 
-// UpdateDBMetrics updates database connection metrics
+// UpdateDBMetrics updates database connection metrics.
 func (d *Database) UpdateDBMetrics() {
-	stats := d.db.Stats()
-	metrics.DBConnectionsOpen.Set(float64(stats.OpenConnections))
+	rStats := d.reader.Stats()
+	wStats := d.writer.Stats()
+	metrics.DBConnectionsOpen.Set(float64(rStats.OpenConnections + wStats.OpenConnections))
 }
 
-// diagnoseDatabasePermissions checks database directory and file permissions
 func diagnoseDatabasePermissions(dbPath string) error {
 	dir := filepath.Dir(dbPath)
 

--- a/internal/database/database_integration_test.go
+++ b/internal/database/database_integration_test.go
@@ -61,7 +61,7 @@ func TestNewDatabase(t *testing.T) {
 
 	// Verify we can ping it
 	ctx := context.Background()
-	if err := db.db.PingContext(ctx); err != nil {
+	if err := db.reader.PingContext(ctx); err != nil {
 		t.Errorf("Database ping failed: %v", err)
 	}
 }
@@ -93,7 +93,7 @@ func TestNewDatabaseWithNilOptions(t *testing.T) {
 	}
 
 	// Verify database is functional
-	if err := db.db.PingContext(ctx); err != nil {
+	if err := db.reader.PingContext(ctx); err != nil {
 		t.Errorf("Database ping failed: %v", err)
 	}
 }
@@ -124,7 +124,7 @@ func TestNewDatabaseWithMmapEnabled(t *testing.T) {
 
 	// Verify read/write works
 	ctx := context.Background()
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
@@ -136,10 +136,10 @@ func TestNewDatabaseWithMmapEnabled(t *testing.T) {
 		Size:       1024,
 		ModTime:    time.Now(),
 	}
-	if err := db.UpsertFile(ctx, tx, file); err != nil {
+	if err := batch.UpsertFile(ctx, file); err != nil {
 		t.Fatalf("UpsertFile failed: %v", err)
 	}
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestNewDatabaseWithMmapDisabled(t *testing.T) {
 
 	// Verify mmap is actually disabled
 	var mmapSize int64
-	if err := db.db.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize); err != nil {
+	if err := db.reader.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize); err != nil {
 		t.Fatalf("Failed to read mmap_size: %v", err)
 	}
 	if mmapSize != 0 {
@@ -185,7 +185,7 @@ func TestNewDatabaseWithMmapDisabled(t *testing.T) {
 	}
 
 	// Verify full read/write cycle works with mmap disabled
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
@@ -198,10 +198,10 @@ func TestNewDatabaseWithMmapDisabled(t *testing.T) {
 		ModTime:    time.Now(),
 		MimeType:   "image/jpeg",
 	}
-	if err := db.UpsertFile(ctx, tx, file); err != nil {
+	if err := batch.UpsertFile(ctx, file); err != nil {
 		t.Fatalf("UpsertFile failed with mmap disabled: %v", err)
 	}
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed with mmap disabled: %v", err)
 	}
 
@@ -332,41 +332,41 @@ func TestUpsertFileIntegration(t *testing.T) {
 	}
 
 	// Insert new file using transaction
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
-	err = db.UpsertFile(ctx, tx, &file)
+	err = batch.UpsertFile(ctx, &file)
 	if err != nil {
 		t.Fatalf("UpsertFile failed on insert: %v", err)
 	}
 
-	err = db.EndBatch(tx, nil)
+	err = db.EndBatch(batch, nil)
 	if err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
 	// Update existing file
 	file.Size = 2048
-	tx, err = db.BeginBatch(ctx)
+	batch, err = db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
-	err = db.UpsertFile(ctx, tx, &file)
+	err = batch.UpsertFile(ctx, &file)
 	if err != nil {
 		t.Fatalf("UpsertFile failed on update: %v", err)
 	}
 
-	err = db.EndBatch(tx, nil)
+	err = db.EndBatch(batch, nil)
 	if err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
 	// Verify file was updated
 	var size int64
-	err = db.db.QueryRowContext(ctx, "SELECT size FROM files WHERE path = ?", file.Path).Scan(&size)
+	err = db.reader.QueryRowContext(ctx, "SELECT size FROM files WHERE path = ?", file.Path).Scan(&size)
 	if err != nil {
 		t.Fatalf("Failed to query file: %v", err)
 	}
@@ -393,18 +393,18 @@ func TestListDirectoryIntegration(t *testing.T) {
 		{Name: "subfolder", Path: "folder1/subfolder", ParentPath: "folder1", Type: FileTypeFolder, Size: 0, ModTime: time.Now()},
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
 	for i := range files {
-		if err := db.UpsertFile(ctx, tx, &files[i]); err != nil {
+		if err := batch.UpsertFile(ctx, &files[i]); err != nil {
 			t.Fatalf("Failed to insert file %s: %v", files[i].Path, err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -485,18 +485,18 @@ func TestSearchIntegration(t *testing.T) {
 		{Name: "beach.mp4", Path: "videos/beach.mp4", ParentPath: "videos", Type: FileTypeVideo, Size: 2048, ModTime: time.Now()},
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
 	for i := range files {
-		if err := db.UpsertFile(ctx, tx, &files[i]); err != nil {
+		if err := batch.UpsertFile(ctx, &files[i]); err != nil {
 			t.Fatalf("Failed to insert file: %v", err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -580,17 +580,17 @@ func TestGetFileByPathIntegration(t *testing.T) {
 		MimeType:   "image/jpeg",
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
-	err = db.UpsertFile(ctx, tx, &file)
+	err = batch.UpsertFile(ctx, &file)
 	if err != nil {
 		t.Fatalf("UpsertFile failed: %v", err)
 	}
 
-	err = db.EndBatch(tx, nil)
+	err = db.EndBatch(batch, nil)
 	if err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
@@ -636,16 +636,16 @@ func TestGetFilesUpdatedSinceIntegration(t *testing.T) {
 		ModTime:    now.Add(-1 * time.Hour),
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
-	if err := db.UpsertFile(ctx, tx, &oldFile); err != nil {
+	if err := batch.UpsertFile(ctx, &oldFile); err != nil {
 		t.Fatalf("Failed to insert old file: %v", err)
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -666,16 +666,16 @@ func TestGetFilesUpdatedSinceIntegration(t *testing.T) {
 		ModTime:    now,
 	}
 
-	tx, err = db.BeginBatch(ctx)
+	batch, err = db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
-	if err := db.UpsertFile(ctx, tx, &newFile); err != nil {
+	if err := batch.UpsertFile(ctx, &newFile); err != nil {
 		t.Fatalf("Failed to insert new file: %v", err)
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -712,18 +712,18 @@ func TestGetSubfoldersIntegration(t *testing.T) {
 		{Name: "grandchild", Path: "parent/child1/grandchild", ParentPath: "parent/child1", Type: FileTypeFolder, Size: 0, ModTime: time.Now()},
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
 	for i := range folders {
-		if err := db.UpsertFile(ctx, tx, &folders[i]); err != nil {
+		if err := batch.UpsertFile(ctx, &folders[i]); err != nil {
 			t.Fatalf("Failed to insert folder: %v", err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -761,18 +761,18 @@ func TestGetMediaFilesInFolderIntegration(t *testing.T) {
 		{Name: "video1.mp4", Path: "folder/video1.mp4", ParentPath: "folder", Type: FileTypeVideo, Size: 2048, ModTime: time.Now()},
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
 	for i := range files {
-		if err := db.UpsertFile(ctx, tx, &files[i]); err != nil {
+		if err := batch.UpsertFile(ctx, &files[i]); err != nil {
 			t.Fatalf("Failed to insert file: %v", err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -840,18 +840,18 @@ func TestCalculateStatsIntegration(t *testing.T) {
 		{Name: "folder", Path: "folder", ParentPath: "", Type: FileTypeFolder, Size: 0, ModTime: time.Now()},
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
 	for i := range files {
-		if err := db.UpsertFile(ctx, tx, &files[i]); err != nil {
+		if err := batch.UpsertFile(ctx, &files[i]); err != nil {
 			t.Fatalf("Failed to insert file: %v", err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -886,7 +886,7 @@ func TestDatabaseConcurrency(t *testing.T) {
 	ctx := context.Background()
 	const numFiles = 100
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
@@ -901,12 +901,12 @@ func TestDatabaseConcurrency(t *testing.T) {
 			ModTime:    time.Now(),
 		}
 
-		if err := db.UpsertFile(ctx, tx, &file); err != nil {
+		if err := batch.UpsertFile(ctx, &file); err != nil {
 			t.Errorf("Insert %d failed: %v", i, err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -944,9 +944,9 @@ func BenchmarkUpsertFile(b *testing.B) {
 			ModTime:    now,
 		}
 
-		tx, _ := db.BeginBatch(ctx)
-		_ = db.UpsertFile(ctx, tx, &file)
-		_ = db.EndBatch(tx, nil)
+		batch, _ := db.BeginBatch(ctx)
+		_ = batch.UpsertFile(ctx, &file)
+		_ = db.EndBatch(batch, nil)
 	}
 }
 
@@ -956,7 +956,7 @@ func BenchmarkListDirectory(b *testing.B) {
 
 	ctx := context.Background()
 
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 	for i := 0; i < 100; i++ {
 		file := MediaFile{
 			Name:       filepath.Base(filepath.Join("bench", string(rune('a'+i%26))+".jpg")),
@@ -966,9 +966,9 @@ func BenchmarkListDirectory(b *testing.B) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, &file)
+		_ = batch.UpsertFile(ctx, &file)
 	}
-	_ = db.EndBatch(tx, nil)
+	_ = db.EndBatch(batch, nil)
 
 	opts := ListOptions{
 		Path:     "bench",
@@ -1000,7 +1000,7 @@ func TestListDirectorySorting(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -1046,7 +1046,7 @@ func TestListDirectoryPagination(t *testing.T) {
 
 	ctx := context.Background()
 
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 	for i := 0; i < 25; i++ {
 		file := MediaFile{
 			Name:       filepath.Base(filepath.Join("page", "file"+string(rune('a'+i%26))+".jpg")),
@@ -1056,9 +1056,9 @@ func TestListDirectoryPagination(t *testing.T) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, &file)
+		_ = batch.UpsertFile(ctx, &file)
 	}
-	_ = db.EndBatch(tx, nil)
+	_ = db.EndBatch(batch, nil)
 
 	tests := []struct {
 		name        string
@@ -1135,7 +1135,7 @@ func TestSearchSuggestions(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -1168,7 +1168,7 @@ func TestGetAllPlaylists(t *testing.T) {
 	}
 
 	tx, _ := db.BeginBatch(ctx)
-	_ = db.UpsertFile(ctx, tx, &playlist)
+	_ = tx.UpsertFile(ctx, &playlist)
 	_ = db.EndBatch(tx, nil)
 
 	playlists, err := db.GetAllPlaylists(ctx)
@@ -1197,11 +1197,11 @@ func TestGetMediaInDirectory(t *testing.T) {
 		{Name: "beta.mp4", Path: "media/beta.mp4", ParentPath: "media", Type: FileTypeVideo, Size: 2048, ModTime: time.Now()},
 	}
 
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = batch.UpsertFile(ctx, &files[i])
 	}
-	_ = db.EndBatch(tx, nil)
+	_ = db.EndBatch(batch, nil)
 
 	mediaFiles, err := db.GetMediaInDirectory(ctx, "media", SortByName, SortAsc)
 	if err != nil {
@@ -1230,7 +1230,7 @@ func TestGetMediaInDirectory_CoveringIndexes(t *testing.T) {
 		WHERE type = 'index'
 		AND name IN ('idx_files_media_directory_name', 'idx_files_media_directory_date', 'idx_files_path')
 	`
-	err := db.db.QueryRowContext(ctx, query).Scan(&indexCount)
+	err := db.reader.QueryRowContext(ctx, query).Scan(&indexCount)
 	if err != nil {
 		t.Fatalf("Failed to check for covering indexes: %v", err)
 	}
@@ -1239,7 +1239,7 @@ func TestGetMediaInDirectory_CoveringIndexes(t *testing.T) {
 		t.Errorf("Expected 3 covering indexes, got %d", indexCount)
 	}
 
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 	baseTime := time.Now().Add(-24 * time.Hour)
 	for i := 0; i < 500; i++ {
 		file := MediaFile{
@@ -1251,9 +1251,9 @@ func TestGetMediaInDirectory_CoveringIndexes(t *testing.T) {
 			ModTime:    baseTime.Add(time.Duration(i) * time.Minute),
 			MimeType:   "image/jpeg",
 		}
-		_ = db.UpsertFile(ctx, tx, &file)
+		_ = batch.UpsertFile(ctx, &file)
 	}
-	_ = db.EndBatch(tx, nil)
+	_ = db.EndBatch(batch, nil)
 
 	files, err := db.GetMediaInDirectory(ctx, "testdir", SortByName, SortAsc)
 	if err != nil {
@@ -1309,7 +1309,7 @@ func TestGetMediaInDirectory_WithFavoritesAndTags(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range insertFiles {
-		_ = db.UpsertFile(ctx, tx, &insertFiles[i])
+		_ = tx.UpsertFile(ctx, &insertFiles[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -1362,7 +1362,7 @@ func TestGetAllMediaFiles(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -1390,7 +1390,7 @@ func TestGetAllMediaFilesForThumbnails(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -1413,14 +1413,14 @@ func TestGetFoldersWithUpdatedContents(t *testing.T) {
 	folder := MediaFile{Name: "photos", Path: "photos", ParentPath: "", Type: FileTypeFolder, Size: 0, ModTime: time.Now()}
 
 	tx, _ := db.BeginBatch(ctx)
-	_ = db.UpsertFile(ctx, tx, &folder)
+	_ = tx.UpsertFile(ctx, &folder)
 	_ = db.EndBatch(tx, nil)
 
 	oldFile := MediaFile{Name: "old.jpg", Path: "photos/old.jpg", ParentPath: "photos", Type: FileTypeImage, Size: 1024, ModTime: time.Now()}
 
-	tx, _ = db.BeginBatch(ctx)
-	_ = db.UpsertFile(ctx, tx, &oldFile)
-	_ = db.EndBatch(tx, nil)
+	batch, _ := db.BeginBatch(ctx)
+	_ = batch.UpsertFile(ctx, &oldFile)
+	_ = db.EndBatch(batch, nil)
 
 	t.Logf("Waiting 11 seconds for timestamp separation...")
 	time.Sleep(11 * time.Second)
@@ -1428,9 +1428,9 @@ func TestGetFoldersWithUpdatedContents(t *testing.T) {
 
 	newFile := MediaFile{Name: "new.jpg", Path: "photos/new.jpg", ParentPath: "photos", Type: FileTypeImage, Size: 1024, ModTime: time.Now()}
 
-	tx, _ = db.BeginBatch(ctx)
-	_ = db.UpsertFile(ctx, tx, &newFile)
-	_ = db.EndBatch(tx, nil)
+	batch, _ = db.BeginBatch(ctx)
+	_ = batch.UpsertFile(ctx, &newFile)
+	_ = db.EndBatch(batch, nil)
 
 	folders, err := db.GetFoldersWithUpdatedContents(ctx, beforeUpdate)
 	if err != nil {
@@ -1463,7 +1463,7 @@ func TestGetAllIndexedPaths(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -1506,7 +1506,7 @@ func TestGetAllIndexedPaths_LargeSet(t *testing.T) {
 	ctx := context.Background()
 
 	fileCount := 1000
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 
 	for i := 0; i < fileCount; i++ {
 		file := MediaFile{
@@ -1517,9 +1517,9 @@ func TestGetAllIndexedPaths_LargeSet(t *testing.T) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, &file)
+		_ = batch.UpsertFile(ctx, &file)
 	}
-	_ = db.EndBatch(tx, nil)
+	_ = db.EndBatch(batch, nil)
 
 	paths, err := db.GetAllIndexedPaths(ctx)
 	if err != nil {
@@ -1629,7 +1629,7 @@ func TestSetupCompleteMigrationIntegration(t *testing.T) {
 	}
 
 	var setupComplete int
-	err = db.db.QueryRowContext(ctx, "SELECT setup_complete FROM users WHERE id = 1").Scan(&setupComplete)
+	err = db.reader.QueryRowContext(ctx, "SELECT setup_complete FROM users WHERE id = 1").Scan(&setupComplete)
 	if err != nil {
 		t.Fatalf("Failed to query setup_complete: %v", err)
 	}
@@ -1650,7 +1650,7 @@ func TestSetupCompleteMigrationIntegration(t *testing.T) {
 	}
 	defer db.Close()
 
-	err = db.db.QueryRowContext(ctx, "SELECT setup_complete FROM users WHERE id = 1").Scan(&setupComplete)
+	err = db.reader.QueryRowContext(ctx, "SELECT setup_complete FROM users WHERE id = 1").Scan(&setupComplete)
 	if err != nil {
 		t.Fatalf("Failed to query setup_complete after reopen: %v", err)
 	}
@@ -1671,7 +1671,7 @@ func TestDatabaseConnectionPoolConcurrency(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
@@ -1681,11 +1681,11 @@ func TestDatabaseConnectionPoolConcurrency(t *testing.T) {
 			Name: "test.jpg", Path: "test/test.jpg", ParentPath: "test",
 			Type: FileTypeImage, Size: 1024, ModTime: now,
 		}
-		if err := db.UpsertFile(ctx, tx, &file); err != nil {
+		if err := batch.UpsertFile(ctx, &file); err != nil {
 			t.Fatalf("UpsertFile failed: %v", err)
 		}
 	}
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -1724,7 +1724,7 @@ func TestBeginBatchNonBlocking(t *testing.T) {
 
 	ctx := context.Background()
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
@@ -1744,7 +1744,7 @@ func TestBeginBatchNonBlocking(t *testing.T) {
 		t.Error("Read blocked by batch transaction lock (should not happen with fix)")
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 }
@@ -1760,7 +1760,7 @@ func TestConnectionPoolUnderLoad(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
@@ -1769,11 +1769,11 @@ func TestConnectionPoolUnderLoad(t *testing.T) {
 			Name: "test.jpg", Path: "test/test.jpg", ParentPath: "test",
 			Type: FileTypeImage, Size: 1024, ModTime: now,
 		}
-		if err := db.UpsertFile(ctx, tx, &file); err != nil {
+		if err := batch.UpsertFile(ctx, &file); err != nil {
 			t.Fatalf("UpsertFile failed: %v", err)
 		}
 	}
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -1807,7 +1807,7 @@ func TestConnectionPoolUnderLoad(t *testing.T) {
 					Size:       1024,
 					ModTime:    now,
 				}
-				if uerr := db.UpsertFile(ctx, wtx, &file); uerr != nil {
+				if uerr := wtx.UpsertFile(ctx, &file); uerr != nil {
 					done <- uerr
 					return
 				}
@@ -1854,7 +1854,7 @@ func TestMmapDisabledOnAllConnections(t *testing.T) {
 	conns := make([]*sql.Conn, 0, numConns)
 
 	for i := 0; i < numConns; i++ {
-		conn, err := db.db.Conn(ctx)
+		conn, err := db.reader.Conn(ctx)
 		if err != nil {
 			t.Fatalf("Failed to get connection %d: %v", i, err)
 		}
@@ -1932,7 +1932,7 @@ func TestMmapDisabledAfterInitialize(t *testing.T) {
 	ctx := context.Background()
 
 	var mmapSize int64
-	err := db.db.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize)
+	err := db.reader.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize)
 	if err != nil {
 		t.Fatalf("Failed to read mmap_size: %v", err)
 	}
@@ -1986,7 +1986,7 @@ func TestNewDatabaseMmapDisabled(t *testing.T) {
 	defer db.Close()
 
 	var mmapSize int64
-	if err := db.db.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize); err != nil {
+	if err := db.reader.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize); err != nil {
 		t.Fatalf("Failed to read mmap_size: %v", err)
 	}
 
@@ -1994,7 +1994,7 @@ func TestNewDatabaseMmapDisabled(t *testing.T) {
 		t.Errorf("New() database has mmap_size=%d, want 0", mmapSize)
 	}
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
@@ -2004,10 +2004,10 @@ func TestNewDatabaseMmapDisabled(t *testing.T) {
 		Type: FileTypeImage, Size: 1024, ModTime: time.Now(), MimeType: "image/jpeg",
 	}
 
-	if err := db.UpsertFile(ctx, tx, file); err != nil {
+	if err := batch.UpsertFile(ctx, file); err != nil {
 		t.Fatalf("UpsertFile failed with mmap disabled: %v", err)
 	}
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed with mmap disabled: %v", err)
 	}
 
@@ -2055,7 +2055,7 @@ func TestMmapDisabledPersistsAcrossReopen(t *testing.T) {
 		Name: "persist.jpg", Path: "persist/persist.jpg", ParentPath: "persist",
 		Type: FileTypeImage, Size: 1024, ModTime: time.Now(),
 	}
-	if err := db1.UpsertFile(ctx, tx, file); err != nil {
+	if err := tx.UpsertFile(ctx, file); err != nil {
 		t.Fatalf("UpsertFile failed: %v", err)
 	}
 	if err := db1.EndBatch(tx, nil); err != nil {
@@ -2071,7 +2071,7 @@ func TestMmapDisabledPersistsAcrossReopen(t *testing.T) {
 	defer db2.Close()
 
 	var mmapSize int64
-	if err := db2.db.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize); err != nil {
+	if err := db2.reader.QueryRowContext(ctx, "PRAGMA mmap_size").Scan(&mmapSize); err != nil {
 		t.Fatalf("Failed to read mmap_size after reopen: %v", err)
 	}
 
@@ -2112,7 +2112,7 @@ func TestMmapModeSwitch(t *testing.T) {
 		Name: "switch.jpg", Path: "switch/switch.jpg", ParentPath: "switch",
 		Type: FileTypeImage, Size: 1024, ModTime: time.Now(),
 	}
-	if err := db1.UpsertFile(ctx, tx, file); err != nil {
+	if err := tx.UpsertFile(ctx, file); err != nil {
 		t.Fatalf("UpsertFile failed: %v", err)
 	}
 	if err := db1.EndBatch(tx, nil); err != nil {
@@ -2255,7 +2255,7 @@ func BenchmarkConnectionPoolAcquisition(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var count int
-		err := db.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM files").Scan(&count)
+		err := db.reader.QueryRowContext(ctx, "SELECT COUNT(*) FROM files").Scan(&count)
 		if err != nil {
 			b.Fatalf("Query failed: %v", err)
 		}
@@ -2270,11 +2270,11 @@ func BenchmarkBeginEndBatch(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tx, err := db.BeginBatch(ctx)
+		batch, err := db.BeginBatch(ctx)
 		if err != nil {
 			b.Fatalf("BeginBatch failed: %v", err)
 		}
-		if err := db.EndBatch(tx, nil); err != nil {
+		if err = db.EndBatch(batch, err); err != nil {
 			b.Fatalf("EndBatch failed: %v", err)
 		}
 	}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -466,50 +466,8 @@ func TestBeginBatchLockingBehavior(t *testing.T) {
 func TestDriverNameConstant(t *testing.T) {
 	t.Parallel()
 
-	if driverName != "sqlite3_mmap_disabled" {
-		t.Errorf("driverName = %q, want %q", driverName, "sqlite3_mmap_disabled")
-	}
-
-	if standardDriverName != "sqlite3" {
-		t.Errorf("standardDriverName = %q, want %q", standardDriverName, "sqlite3")
-	}
-}
-
-// TestActiveDriverName verifies driver selection based on options.
-func TestActiveDriverName(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		opts     *Options
-		wantName string
-	}{
-		{
-			name:     "nil options uses standard driver",
-			opts:     nil,
-			wantName: standardDriverName,
-		},
-		{
-			name:     "mmap enabled uses standard driver",
-			opts:     &Options{MmapDisabled: false},
-			wantName: standardDriverName,
-		},
-		{
-			name:     "mmap disabled uses custom driver",
-			opts:     &Options{MmapDisabled: true},
-			wantName: driverName,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := activeDriverName(tt.opts)
-			if got != tt.wantName {
-				t.Errorf("activeDriverName(%+v) = %q, want %q", tt.opts, got, tt.wantName)
-			}
-		})
+	if driverName != "sqlite3_custom" {
+		t.Errorf("driverName = %q, want %q", driverName, "sqlite3_custom")
 	}
 }
 
@@ -535,11 +493,11 @@ func TestOptionsStruct(t *testing.T) {
 func TestRegisterDriverIdempotent(t *testing.T) {
 	t.Parallel()
 
-	// registerDriver() was already called by init().
+	// registerDriver() was already called during init or New().
 	// Calling it again should be a no-op via sync.Once.
-	registerDriver()
-	registerDriver()
-	registerDriver()
+	registerDriver(nil)
+	registerDriver(&Options{MmapDisabled: true})
+	registerDriver(nil)
 
 	// If we got here without panicking, the test passes.
 }

--- a/internal/database/favorites.go
+++ b/internal/database/favorites.go
@@ -12,9 +12,6 @@ import (
 func (d *Database) AddFavorite(ctx context.Context, path, name string, fileType FileType) error {
 	done := observeQuery("add_favorite")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
@@ -24,67 +21,49 @@ func (d *Database) AddFavorite(ctx context.Context, path, name string, fileType 
 		ON CONFLICT(path) DO NOTHING
 	`
 
-	_, err := d.db.ExecContext(ctx, query, path, name, fileType, time.Now().Unix())
+	_, err := d.writer.ExecContext(ctx, query, path, name, fileType, time.Now().Unix())
 	done(err)
 	return err
 }
 
-// RemoveFavorite removes a path from favorites.
+// RemoveFavorite removes a favorite by its path.
 func (d *Database) RemoveFavorite(ctx context.Context, path string) error {
 	done := observeQuery("remove_favorite")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(ctx, "DELETE FROM favorites WHERE path = ?", path)
+	_, err := d.writer.ExecContext(ctx, "DELETE FROM favorites WHERE path = ?", path)
 	done(err)
 	return err
 }
 
-// IsFavorite checks if a path is a favorite.
+// IsFavorite uses a prepared statement for the favorite check.
 func (d *Database) IsFavorite(ctx context.Context, path string) bool {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	return d.isFavoriteUnlocked(ctx, path)
-}
-
-// isFavoriteUnlocked checks favorite status without acquiring lock.
-// Caller must hold at least a read lock.
-func (d *Database) isFavoriteUnlocked(ctx context.Context, path string) bool {
-	var count int
-	err := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM favorites WHERE path = ?", path).Scan(&count)
+	var exists bool
+	err := d.stmts.isFavorite.QueryRowContext(ctx, path).Scan(&exists)
 	if err != nil {
 		return false
 	}
-	return count > 0
+	return exists
 }
 
 // GetFavorites returns all favorites with their file info.
 func (d *Database) GetFavorites(ctx context.Context) ([]MediaFile, error) {
 	done := observeQuery("get_favorites")
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	result, err := d.getFavoritesUnlocked(ctx)
+	result, err := d.getFavorites(ctx)
 	done(err)
 	return result, err
 }
 
-// getFavoritesUnlocked returns favorites without acquiring lock.
-// Caller must hold at least a read lock.
-func (d *Database) getFavoritesUnlocked(ctx context.Context) ([]MediaFile, error) {
-	// Optimized query with LEFT JOIN for folder counts (eliminates N+1 for folders)
+func (d *Database) getFavorites(ctx context.Context) ([]MediaFile, error) {
 	query := `
 		SELECT
 			f.id, f.name, f.path, f.parent_path, f.type, f.size, f.mod_time, f.mime_type,
@@ -99,13 +78,13 @@ func (d *Database) getFavoritesUnlocked(ctx context.Context) ([]MediaFile, error
 		ORDER BY fav.created_at DESC
 	`
 
-	rows, err := d.db.QueryContext(ctx, query)
+	rows, err := d.reader.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get favorites: %w", err)
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {
-			logging.Error("error closing rows in getFavoritesUnlocked: %v", err)
+			logging.Error("error closing rows in getFavorites: %v", err)
 		}
 	}()
 
@@ -146,14 +125,11 @@ func (d *Database) getFavoritesUnlocked(ctx context.Context) ([]MediaFile, error
 
 // GetFavoriteCount returns the number of favorites.
 func (d *Database) GetFavoriteCount(ctx context.Context) int {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var count int
-	if err := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM favorites").Scan(&count); err != nil {
+	if err := d.reader.QueryRowContext(ctx, "SELECT COUNT(*) FROM favorites").Scan(&count); err != nil {
 		return 0
 	}
 	return count

--- a/internal/database/favorites_integration_test.go
+++ b/internal/database/favorites_integration_test.go
@@ -122,7 +122,7 @@ func TestGetFavoritesIntegration(t *testing.T) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, file)
+		_ = tx.UpsertFile(ctx, file)
 	}
 	_ = db.EndBatch(tx, nil)
 

--- a/internal/database/metadata.go
+++ b/internal/database/metadata.go
@@ -8,16 +8,12 @@ import (
 )
 
 // GetMetadata retrieves a metadata value by key.
-// Returns error if the key doesn't exist.
 func (d *Database) GetMetadata(ctx context.Context, key string) (string, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var value string
-	err := d.db.QueryRowContext(ctx, "SELECT value FROM metadata WHERE key = ?", key).Scan(&value)
+	err := d.reader.QueryRowContext(ctx, "SELECT value FROM metadata WHERE key = ?", key).Scan(&value)
 	if err == sql.ErrNoRows {
 		return "", sql.ErrNoRows
 	}
@@ -29,13 +25,10 @@ func (d *Database) GetMetadata(ctx context.Context, key string) (string, error) 
 
 // SetMetadata sets a metadata key-value pair.
 func (d *Database) SetMetadata(ctx context.Context, key, value string) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(ctx, `
+	_, err := d.writer.ExecContext(ctx, `
 		INSERT INTO metadata (key, value) VALUES (?, ?)
 		ON CONFLICT(key) DO UPDATE SET value = excluded.value
 	`, key, value)
@@ -43,11 +36,9 @@ func (d *Database) SetMetadata(ctx context.Context, key, value string) error {
 }
 
 // GetLastThumbnailRun returns the timestamp of the last thumbnail generation run.
-// Returns zero time if never run.
 func (d *Database) GetLastThumbnailRun(ctx context.Context) (time.Time, error) {
 	value, err := d.GetMetadata(ctx, "last_thumbnail_run")
 	if errors.Is(err, sql.ErrNoRows) {
-		// Key doesn't exist, never run
 		return time.Time{}, nil
 	}
 	if err != nil {
@@ -67,7 +58,6 @@ func (d *Database) GetLastThumbnailRun(ctx context.Context) (time.Time, error) {
 // SetLastThumbnailRun stores the timestamp of the last thumbnail generation run.
 func (d *Database) SetLastThumbnailRun(ctx context.Context, t time.Time) error {
 	if t.IsZero() {
-		// Clear the value
 		return d.SetMetadata(ctx, "last_thumbnail_run", "")
 	}
 	return d.SetMetadata(ctx, "last_thumbnail_run", t.Format(time.RFC3339))

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -75,14 +75,11 @@ func (d *Database) ListDirectory(ctx context.Context, opts ListOptions) (*Direct
 
 	opts = normalizeListOptions(opts)
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	totalItems, err := d.countDirectoryItemsUnlocked(ctx, opts)
+	totalItems, err := d.countDirectoryItems(ctx, opts)
 	if err != nil {
 		done(err)
 		return nil, err
@@ -90,13 +87,13 @@ func (d *Database) ListDirectory(ctx context.Context, opts ListOptions) (*Direct
 
 	logging.Debug("ListDirectory: count=%d, getting items...", totalItems)
 
-	items, err := d.fetchDirectoryItemsUnlocked(ctx, opts)
+	items, err := d.fetchDirectoryItems(ctx, opts)
 	if err != nil {
 		done(err)
 		return nil, err
 	}
 
-	listing := d.buildDirectoryListingUnlocked(ctx, opts, items, totalItems)
+	listing := d.buildDirectoryListing(ctx, opts, items, totalItems)
 
 	logging.Debug("ListDirectory completed")
 
@@ -123,7 +120,7 @@ func normalizeListOptions(opts ListOptions) ListOptions {
 	return opts
 }
 
-// countDirectoryItemsUnlocked returns the total count of items in a directory.
+// countDirectoryItems returns the total count of items in a directory.
 // Constants for query values
 const (
 	SortAscStr       = "ASC"
@@ -131,20 +128,19 @@ const (
 	NameCollationStr = "f.name COLLATE NOCASE"
 )
 
-// Caller must hold at least a read lock.
-func (d *Database) countDirectoryItemsUnlocked(ctx context.Context, opts ListOptions) (int, error) {
+// countDirectoryItems uses prepared statements for the count query.
+func (d *Database) countDirectoryItems(ctx context.Context, opts ListOptions) (int, error) {
 	logging.Debug("ListDirectory: getting count...")
 
-	countQuery := `SELECT COUNT(*) FROM files WHERE parent_path = ?`
-	countArgs := []interface{}{opts.Path}
+	var totalItems int
+	var err error
 
 	if opts.FilterType != "" {
-		countQuery += ` AND (type = 'folder' OR type = ?)`
-		countArgs = append(countArgs, opts.FilterType)
+		err = d.stmts.countDirItemsFilter.QueryRowContext(ctx, opts.Path, opts.FilterType).Scan(&totalItems)
+	} else {
+		err = d.stmts.countDirItems.QueryRowContext(ctx, opts.Path).Scan(&totalItems)
 	}
 
-	var totalItems int
-	err := d.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&totalItems)
 	if err != nil {
 		logging.Error("ListDirectory count query failed: %v", err)
 		return 0, fmt.Errorf("count query failed: %w", err)
@@ -153,9 +149,8 @@ func (d *Database) countDirectoryItemsUnlocked(ctx context.Context, opts ListOpt
 	return totalItems, nil
 }
 
-// fetchDirectoryItemsUnlocked retrieves the items for the current page.
-// Caller must hold at least a read lock.
-func (d *Database) fetchDirectoryItemsUnlocked(ctx context.Context, opts ListOptions) ([]MediaFile, error) {
+// fetchDirectoryItems retrieves the items for the current page.
+func (d *Database) fetchDirectoryItems(ctx context.Context, opts ListOptions) ([]MediaFile, error) {
 	logging.Debug("ListDirectory: executing select query...")
 
 	sortColumn := getSortColumn(opts.SortField)
@@ -165,28 +160,6 @@ func (d *Database) fetchDirectoryItemsUnlocked(ctx context.Context, opts ListOpt
 	}
 
 	offset := (opts.Page - 1) * opts.PageSize
-
-	selectQuery := `
-		SELECT
-			f.id, f.name, f.path, f.parent_path, f.type, f.size, f.mod_time, f.mime_type,
-			EXISTS(SELECT 1 FROM favorites WHERE path = f.path) AS is_favorite,
-			(SELECT GROUP_CONCAT(t.name, ',')
-			 FROM file_tags ft
-			 JOIN tags t ON ft.tag_id = t.id
-			 WHERE ft.file_path = f.path) AS tags,
-			CASE WHEN f.type = 'folder'
-				THEN (SELECT COUNT(*) FROM files WHERE parent_path = f.path)
-				ELSE 0
-			END AS folder_count
-		FROM files f
-		WHERE f.parent_path = ?
-	`
-	selectArgs := []interface{}{opts.Path}
-
-	if opts.FilterType != "" {
-		selectQuery += ` AND (f.type = 'folder' OR f.type = ?)`
-		selectArgs = append(selectArgs, opts.FilterType)
-	}
 
 	var orderColumn string
 	if sortColumn == NameCollation {
@@ -211,11 +184,34 @@ func (d *Database) fetchDirectoryItemsUnlocked(ctx context.Context, opts ListOpt
 	if !allowedSortDirs[sortDir] {
 		sortDir = SortAscStr
 	}
-	selectQuery += fmt.Sprintf(` ORDER BY (CASE WHEN f.type = 'folder' THEN 0 ELSE 1 END), %s %s`, orderColumn, sortDir) //nolint:gosec // G202 - orderColumn and sortDir are validated against static allowlists
+
+	selectQuery := `
+		SELECT
+			f.id, f.name, f.path, f.parent_path, f.type, f.size, f.mod_time, f.mime_type,
+			EXISTS(SELECT 1 FROM favorites WHERE path = f.path) AS is_favorite,
+			(SELECT GROUP_CONCAT(t.name, ',')
+			 FROM file_tags ft
+			 JOIN tags t ON ft.tag_id = t.id
+			 WHERE ft.file_path = f.path) AS tags,
+			CASE WHEN f.type = 'folder'
+				THEN (SELECT COUNT(*) FROM files WHERE parent_path = f.path)
+				ELSE 0
+			END AS folder_count
+		FROM files f
+		WHERE f.parent_path = ?
+	`
+	selectArgs := []interface{}{opts.Path}
+
+	if opts.FilterType != "" {
+		selectQuery += ` AND (f.type = 'folder' OR f.type = ?)`
+		selectArgs = append(selectArgs, opts.FilterType)
+	}
+
+	selectQuery += fmt.Sprintf(` ORDER BY (CASE WHEN f.type = 'folder' THEN 0 ELSE 1 END), %s %s`, orderColumn, sortDir) //nolint:gosec
 	selectQuery += ` LIMIT ? OFFSET ?`
 	selectArgs = append(selectArgs, opts.PageSize, offset)
 
-	rows, err := d.db.QueryContext(ctx, selectQuery, selectArgs...)
+	rows, err := d.reader.QueryContext(ctx, selectQuery, selectArgs...)
 	if err != nil {
 		logging.Error("ListDirectory select query failed: %v", err)
 		return nil, fmt.Errorf("select query failed: %w", err)
@@ -226,7 +222,7 @@ func (d *Database) fetchDirectoryItemsUnlocked(ctx context.Context, opts ListOpt
 		}
 	}()
 
-	return d.scanDirectoryItemsUnlocked(rows)
+	return d.scanDirectoryItems(rows)
 }
 
 // getSortColumn returns the SQL column for sorting.
@@ -245,9 +241,8 @@ func getSortColumn(field SortField) string {
 	}
 }
 
-// scanDirectoryItemsUnlocked scans rows into MediaFile structs with all data from optimized query.
-// Caller must hold at least a read lock.
-func (d *Database) scanDirectoryItemsUnlocked(rows *sql.Rows) ([]MediaFile, error) {
+// scanDirectoryItems scans rows into MediaFile structs with all data from optimized query.
+func (d *Database) scanDirectoryItems(rows *sql.Rows) ([]MediaFile, error) {
 	logging.Debug("ListDirectory: scanning rows...")
 
 	items := make([]MediaFile, 0, 128)
@@ -297,9 +292,8 @@ func (d *Database) scanDirectoryItemsUnlocked(rows *sql.Rows) ([]MediaFile, erro
 	return items, nil
 }
 
-// buildDirectoryListingUnlocked constructs the final DirectoryListing response.
-// Caller must hold at least a read lock.
-func (d *Database) buildDirectoryListingUnlocked(ctx context.Context, opts ListOptions, items []MediaFile, totalItems int) *DirectoryListing {
+// buildDirectoryListing constructs the final DirectoryListing response.
+func (d *Database) buildDirectoryListing(ctx context.Context, opts ListOptions, items []MediaFile, totalItems int) *DirectoryListing {
 	logging.Debug("ListDirectory: building response...")
 
 	totalPages := int(math.Ceil(float64(totalItems) / float64(opts.PageSize)))
@@ -335,7 +329,7 @@ func (d *Database) buildDirectoryListingUnlocked(ctx context.Context, opts ListO
 	}
 
 	if opts.Path == "" && opts.Page == 1 {
-		favorites, err := d.getFavoritesUnlocked(ctx)
+		favorites, err := d.getFavorites(ctx)
 		if err == nil && len(favorites) > 0 {
 			listing.Favorites = favorites
 		}
@@ -412,9 +406,6 @@ func (d *Database) Search(ctx context.Context, opts SearchOptions) (*SearchResul
 		}
 	}
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -423,19 +414,19 @@ func (d *Database) Search(ctx context.Context, opts SearchOptions) (*SearchResul
 
 	switch {
 	case textQuery == "" && len(tagFilters) > 0:
-		result, err = d.searchByTagFiltersUnlocked(ctx, opts, includedTags, excludedTags)
+		result, err = d.searchByTagFilters(ctx, opts, includedTags, excludedTags)
 	case textQuery == "" && len(tagFilters) == 0:
 		result = &SearchResult{Items: []MediaFile{}, Query: opts.Query}
 	default:
-		result, err = d.searchWithTagFiltersUnlocked(ctx, opts, textQuery, includedTags, excludedTags)
+		result, err = d.searchWithTagFilters(ctx, opts, textQuery, includedTags, excludedTags)
 	}
 
 	done(err)
 	return result, err
 }
 
-// searchByTagFiltersUnlocked handles searches with only tag filters (no text)
-func (d *Database) searchByTagFiltersUnlocked(ctx context.Context, opts SearchOptions, includedTags, excludedTags []string) (*SearchResult, error) {
+// searchByTagFilters handles searches with only tag filters (no text)
+func (d *Database) searchByTagFilters(ctx context.Context, opts SearchOptions, includedTags, excludedTags []string) (*SearchResult, error) {
 	var conditions []string
 	var args []interface{}
 
@@ -477,7 +468,7 @@ func (d *Database) searchByTagFiltersUnlocked(ctx context.Context, opts SearchOp
 		inclusionJoins, whereClause)
 
 	var totalItems int
-	err := d.db.QueryRowContext(ctx, countQuery, args...).Scan(&totalItems)
+	err := d.reader.QueryRowContext(ctx, countQuery, args...).Scan(&totalItems)
 	if err != nil {
 		return nil, fmt.Errorf("count query failed: %w", err)
 	}
@@ -506,7 +497,7 @@ func (d *Database) searchByTagFiltersUnlocked(ctx context.Context, opts SearchOp
 	copy(selectArgs, args)
 	selectArgs = append(selectArgs, opts.PageSize, offset)
 
-	rows, err := d.db.QueryContext(ctx, selectQuery, selectArgs...)
+	rows, err := d.reader.QueryContext(ctx, selectQuery, selectArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("select query failed: %w", err)
 	}
@@ -561,8 +552,8 @@ func (d *Database) searchByTagFiltersUnlocked(ctx context.Context, opts SearchOp
 	}, nil
 }
 
-// searchWithTagFiltersUnlocked handles combined text + tag filter searches
-func (d *Database) searchWithTagFiltersUnlocked(ctx context.Context, opts SearchOptions, textQuery string, includedTags, excludedTags []string) (*SearchResult, error) {
+// searchWithTagFilters handles combined text + tag filter searches
+func (d *Database) searchWithTagFilters(ctx context.Context, opts SearchOptions, textQuery string, includedTags, excludedTags []string) (*SearchResult, error) {
 	searchTerm := prepareSearchTerm(textQuery)
 	tagPattern := "%" + textQuery + "%"
 
@@ -604,7 +595,7 @@ func (d *Database) searchWithTagFiltersUnlocked(ctx context.Context, opts Search
 		filterArgs = append(filterArgs, opts.FilterType)
 	}
 
-	// FTS query using scalar subqueries — no GROUP BY needed
+	// FTS query using scalar subqueries
 	ftsQuery := fmt.Sprintf(`
 		SELECT f.id, f.name, f.path, f.parent_path, f.type, f.size, f.mod_time, f.mime_type,
 		       EXISTS(SELECT 1 FROM favorites WHERE path = f.path) AS is_favorite,
@@ -620,7 +611,7 @@ func (d *Database) searchWithTagFiltersUnlocked(ctx context.Context, opts Search
 		%s
 	`, inclusionJoins, filterClause, exclusionClause)
 
-	// Tag name query using scalar subqueries — no GROUP BY needed
+	// Tag name query using scalar subqueries
 	tagQuery := fmt.Sprintf(`
 		SELECT f.id, f.name, f.path, f.parent_path, f.type, f.size, f.mod_time, f.mime_type,
 		       EXISTS(SELECT 1 FROM favorites WHERE path = f.path) AS is_favorite,
@@ -659,7 +650,7 @@ func (d *Database) searchWithTagFiltersUnlocked(ctx context.Context, opts Search
 		ORDER BY name COLLATE NOCASE
 	`, ftsQuery, tagQuery)
 
-	// Count query — simplified without JOINs for favorites/tags
+	// Count query
 	ftsCountQuery := fmt.Sprintf(`
 		SELECT DISTINCT f.path
 		FROM files f
@@ -692,10 +683,10 @@ func (d *Database) searchWithTagFiltersUnlocked(ctx context.Context, opts Search
 	countArgs = append(countArgs, tagArgs...)
 
 	var totalItems int
-	err := d.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&totalItems)
+	err := d.reader.QueryRowContext(ctx, countQuery, countArgs...).Scan(&totalItems)
 	if err != nil {
 		logging.Warn("Combined search count failed, trying tag-only: %v", err)
-		return d.searchByTagFiltersUnlocked(ctx, opts, includedTags, excludedTags)
+		return d.searchByTagFilters(ctx, opts, includedTags, excludedTags)
 	}
 
 	totalPages := (totalItems + opts.PageSize - 1) / opts.PageSize
@@ -711,10 +702,10 @@ func (d *Database) searchWithTagFiltersUnlocked(ctx context.Context, opts Search
 	selectArgs = append(selectArgs, tagArgs...)
 	selectArgs = append(selectArgs, opts.PageSize, offset)
 
-	rows, err := d.db.QueryContext(ctx, paginatedQuery, selectArgs...)
+	rows, err := d.reader.QueryContext(ctx, paginatedQuery, selectArgs...)
 	if err != nil {
 		logging.Warn("Combined search select failed: %v", err)
-		return d.searchByTagFiltersUnlocked(ctx, opts, includedTags, excludedTags)
+		return d.searchByTagFilters(ctx, opts, includedTags, excludedTags)
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {
@@ -778,9 +769,6 @@ func (d *Database) SearchSuggestions(ctx context.Context, query string, limit in
 
 	limit = normalizeLimit(limit)
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
@@ -820,21 +808,21 @@ func (d *Database) handleTagQuery(ctx context.Context, query, queryLower string,
 
 	if strings.HasPrefix(queryLower, "not "+TagPrefix) {
 		tagQuery := query[8:]
-		suggestions, _ := d.getTagSuggestionsForExclusionUnlocked(ctx, tagQuery, limit, true)
+		suggestions, _ := d.getTagSuggestionsForExclusion(ctx, tagQuery, limit, true)
 		return suggestions, true
 	}
 
 	if strings.HasPrefix(queryLower, "not ") {
 		remainder := strings.ToLower(query[4:])
 		if strings.HasPrefix(TagPrefix, remainder) || strings.HasPrefix(remainder, "tag") {
-			suggestions, _ := d.getTagSuggestionsForExclusionUnlocked(ctx, "", limit, true)
+			suggestions, _ := d.getTagSuggestionsForExclusion(ctx, "", limit, true)
 			return suggestions, true
 		}
 	}
 
 	if strings.HasPrefix(queryLower, TagPrefix) {
 		tagQuery := query[4:]
-		suggestions, _ := d.getTagSuggestionsUnlocked(ctx, tagQuery, limit)
+		suggestions, _ := d.getTagSuggestions(ctx, tagQuery, limit)
 		return suggestions, true
 	}
 
@@ -848,16 +836,16 @@ func (d *Database) handleExclusionQuery(ctx context.Context, query string, limit
 
 	if strings.HasPrefix(remainderLower, TagPrefix) {
 		tagQuery := remainder[4:]
-		suggestions, _ := d.getTagSuggestionsForExclusionUnlocked(ctx, tagQuery, limit, true)
+		suggestions, _ := d.getTagSuggestionsForExclusion(ctx, tagQuery, limit, true)
 		return suggestions
 	}
 
 	if strings.HasPrefix(TagPrefix, remainderLower) || strings.HasPrefix(remainderLower, "tag") {
-		suggestions, _ := d.getTagSuggestionsForExclusionUnlocked(ctx, "", limit, true)
+		suggestions, _ := d.getTagSuggestionsForExclusion(ctx, "", limit, true)
 		return suggestions
 	}
 
-	suggestions, _ := d.getTagSuggestionsForExclusionUnlocked(ctx, remainder, limit, true)
+	suggestions, _ := d.getTagSuggestionsForExclusion(ctx, remainder, limit, true)
 	return suggestions
 }
 
@@ -865,7 +853,7 @@ func (d *Database) handleExclusionQuery(ctx context.Context, query string, limit
 func (d *Database) performRegularSearch(ctx context.Context, query string, limit int) []SearchSuggestion {
 	var suggestions []SearchSuggestion
 
-	tagSuggestions, _ := d.getTagSuggestionsUnlocked(ctx, query, limit/2)
+	tagSuggestions, _ := d.getTagSuggestions(ctx, query, limit/2)
 	suggestions = append(suggestions, tagSuggestions...)
 
 	remainingLimit := limit - len(suggestions)
@@ -884,15 +872,15 @@ func (d *Database) searchFileSuggestions(ctx context.Context, query string, limi
 	searchTerm := prepareSearchTerm(query)
 
 	sqlQuery := `
-		SELECT f.name, f.path, f.type, bm25(files_fts) as rank
-		FROM files f
-		INNER JOIN files_fts fts ON f.id = fts.rowid
-		WHERE files_fts MATCH ?
-		ORDER BY rank
-		LIMIT ?
-	`
+	SELECT f.name, f.path, f.type, bm25(files_fts) as rank
+	FROM files f
+	INNER JOIN files_fts fts ON f.id = fts.rowid
+	WHERE files_fts MATCH ?
+	ORDER BY rank
+	LIMIT ?
+`
 
-	rows, err := d.db.QueryContext(ctx, sqlQuery, searchTerm, limit)
+	rows, err := d.reader.QueryContext(ctx, sqlQuery, searchTerm, limit)
 	if err != nil {
 		return []SearchSuggestion{}
 	}
@@ -918,31 +906,31 @@ func (d *Database) searchFileSuggestions(ctx context.Context, query string, limi
 	return suggestions
 }
 
-// getTagSuggestionsForExclusionUnlocked returns tag suggestions for exclusion queries
-func (d *Database) getTagSuggestionsForExclusionUnlocked(ctx context.Context, query string, limit int, isExclusion bool) ([]SearchSuggestion, error) {
+// getTagSuggestionsForExclusion returns tag suggestions for exclusion queries
+func (d *Database) getTagSuggestionsForExclusion(ctx context.Context, query string, limit int, isExclusion bool) ([]SearchSuggestion, error) {
 	var rows *sql.Rows
 	var err error
 
 	if query == "" {
-		rows, err = d.db.QueryContext(ctx, `
-			SELECT t.name, COUNT(ft.id) as item_count
-			FROM tags t
-			LEFT JOIN file_tags ft ON t.id = ft.tag_id
-			GROUP BY t.id
-			ORDER BY item_count DESC, t.name COLLATE NOCASE
-			LIMIT ?
-		`, limit)
+		rows, err = d.reader.QueryContext(ctx, `
+		SELECT t.name, COUNT(ft.id) as item_count
+		FROM tags t
+		LEFT JOIN file_tags ft ON t.id = ft.tag_id
+		GROUP BY t.id
+		ORDER BY item_count DESC, t.name COLLATE NOCASE
+		LIMIT ?
+	`, limit)
 	} else {
 		searchPattern := "%" + query + "%"
-		rows, err = d.db.QueryContext(ctx, `
-			SELECT t.name, COUNT(ft.id) as item_count
-			FROM tags t
-			LEFT JOIN file_tags ft ON t.id = ft.tag_id
-			WHERE t.name LIKE ?
-			GROUP BY t.id
-			ORDER BY item_count DESC, t.name COLLATE NOCASE
-			LIMIT ?
-		`, searchPattern, limit)
+		rows, err = d.reader.QueryContext(ctx, `
+		SELECT t.name, COUNT(ft.id) as item_count
+		FROM tags t
+		LEFT JOIN file_tags ft ON t.id = ft.tag_id
+		WHERE t.name LIKE ?
+		GROUP BY t.id
+		ORDER BY item_count DESC, t.name COLLATE NOCASE
+		LIMIT ?
+	`, searchPattern, limit)
 	}
 
 	if err != nil {
@@ -987,31 +975,30 @@ func (d *Database) getTagSuggestionsForExclusionUnlocked(ctx context.Context, qu
 	return suggestions, nil
 }
 
-// getTagSuggestionsUnlocked returns tags matching the query as search suggestions.
-// Caller must hold at least a read lock.
-func (d *Database) getTagSuggestionsUnlocked(ctx context.Context, query string, limit int) ([]SearchSuggestion, error) {
+// getTagSuggestions returns tags matching the query as search suggestions.
+func (d *Database) getTagSuggestions(ctx context.Context, query string, limit int) ([]SearchSuggestion, error) {
 	var rows *sql.Rows
 	var err error
 
 	if query == "" {
-		rows, err = d.db.QueryContext(ctx, `
-			SELECT t.name, COUNT(ft.id) as item_count
-			FROM tags t
-			LEFT JOIN file_tags ft ON t.id = ft.tag_id
-			GROUP BY t.id
-			ORDER BY item_count DESC, t.name COLLATE NOCASE
-			LIMIT ?
-		`, limit)
+		rows, err = d.reader.QueryContext(ctx, `
+		SELECT t.name, COUNT(ft.id) as item_count
+		FROM tags t
+		LEFT JOIN file_tags ft ON t.id = ft.tag_id
+		GROUP BY t.id
+		ORDER BY item_count DESC, t.name COLLATE NOCASE
+		LIMIT ?
+	`, limit)
 	} else {
-		rows, err = d.db.QueryContext(ctx, `
-			SELECT t.name, COUNT(ft.id) as item_count
-			FROM tags t
-			LEFT JOIN file_tags ft ON t.id = ft.tag_id
-			WHERE t.name LIKE ?
-			GROUP BY t.id
-			ORDER BY item_count DESC, t.name COLLATE NOCASE
-			LIMIT ?
-		`, "%"+query+"%", limit)
+		rows, err = d.reader.QueryContext(ctx, `
+		SELECT t.name, COUNT(ft.id) as item_count
+		FROM tags t
+		LEFT JOIN file_tags ft ON t.id = ft.tag_id
+		WHERE t.name LIKE ?
+		GROUP BY t.id
+		ORDER BY item_count DESC, t.name COLLATE NOCASE
+		LIMIT ?
+	`, "%"+query+"%", limit)
 	}
 
 	if err != nil {
@@ -1077,9 +1064,6 @@ func highlightMatch(text, query string) string {
 func (d *Database) GetAllPlaylists(ctx context.Context) ([]MediaFile, error) {
 	done := observeQuery("get_all_playlists")
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
@@ -1089,7 +1073,7 @@ func (d *Database) GetAllPlaylists(ctx context.Context) ([]MediaFile, error) {
 		ORDER BY name COLLATE NOCASE
 	`
 
-	rows, err := d.db.QueryContext(ctx, query)
+	rows, err := d.reader.QueryContext(ctx, query)
 	if err != nil {
 		done(err)
 		return nil, err
@@ -1127,15 +1111,8 @@ func (d *Database) GetAllPlaylists(ctx context.Context) ([]MediaFile, error) {
 }
 
 // GetMediaInDirectory returns all media files in a directory (for lightbox).
-// Optimized to fetch favorites and tags in a single query using JOINs to eliminate N+1 queries.
-// GetMediaInDirectory returns all media files in a directory (for lightbox).
-// Uses a correlated subquery approach to avoid row multiplication from tag JOINs,
-// and eliminates the expensive GROUP BY over joined columns.
 func (d *Database) GetMediaInDirectory(ctx context.Context, parentPath string, sortField SortField, sortOrder SortOrder) ([]MediaFile, error) {
 	done := observeQuery("get_media_in_directory")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -1159,7 +1136,7 @@ func (d *Database) GetMediaInDirectory(ctx context.Context, parentPath string, s
 		sortColumn = "f." + sortColumn
 	}
 
-	// Validate against allowlists (same pattern as ListDirectory)
+	// Validate against allowlists
 	allowedColumns := map[string]bool{
 		"f.name COLLATE NOCASE": true,
 		"f.mod_time":            true,
@@ -1195,7 +1172,7 @@ func (d *Database) GetMediaInDirectory(ctx context.Context, parentPath string, s
 		ORDER BY %s %s%s
 	`, sortColumn, sortDir, secondarySort) //nolint:gosec // G202 - sortColumn and sortDir validated against static allowlists
 
-	rows, err := d.db.QueryContext(ctx, query, parentPath)
+	rows, err := d.reader.QueryContext(ctx, query, parentPath)
 	if err != nil {
 		done(err)
 		return nil, err
@@ -1244,9 +1221,6 @@ func (d *Database) GetMediaInDirectory(ctx context.Context, parentPath string, s
 
 // GetMediaFilesInFolder returns media files directly within a folder (for folder thumbnails).
 func (d *Database) GetMediaFilesInFolder(ctx context.Context, folderPath string, limit int) ([]MediaFile, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
@@ -1262,7 +1236,7 @@ func (d *Database) GetMediaFilesInFolder(ctx context.Context, folderPath string,
 		LIMIT ?
 	`
 
-	rows, err := d.db.QueryContext(ctx, query, folderPath, FileTypeImage, FileTypeVideo, limit)
+	rows, err := d.reader.QueryContext(ctx, query, folderPath, FileTypeImage, FileTypeVideo, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1293,32 +1267,16 @@ func (d *Database) GetMediaFilesInFolder(ctx context.Context, folderPath string,
 	return files, rows.Err()
 }
 
-// CalculateStats calculates current index statistics.
-// This method uses its own context as it's typically called from non-HTTP contexts.
+// CalculateStats uses a prepared statement for the stats query.
 func (d *Database) CalculateStats() (IndexStats, error) {
 	done := observeQuery("calculate_stats")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	var stats IndexStats
 
-	query := `
-		SELECT
-			COALESCE(SUM(CASE WHEN type != 'folder' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN type = 'folder' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN type = 'image' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN type = 'video' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN type = 'playlist' THEN 1 ELSE 0 END), 0),
-			(SELECT COUNT(*) FROM favorites),
-			(SELECT COUNT(*) FROM tags)
-		FROM files
-	`
-
-	err := d.db.QueryRowContext(ctx, query).Scan(
+	err := d.stmts.calcStats.QueryRowContext(ctx).Scan(
 		&stats.TotalFiles,
 		&stats.TotalFolders,
 		&stats.TotalImages,
@@ -1338,9 +1296,6 @@ func (d *Database) CalculateStats() (IndexStats, error) {
 
 // GetSubfolders returns all immediate subfolders of a given path.
 func (d *Database) GetSubfolders(ctx context.Context, parentPath string) ([]MediaFile, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
@@ -1351,7 +1306,7 @@ func (d *Database) GetSubfolders(ctx context.Context, parentPath string) ([]Medi
 		ORDER BY name COLLATE NOCASE
 	`
 
-	rows, err := d.db.QueryContext(ctx, query, parentPath, FileTypeFolder)
+	rows, err := d.reader.QueryContext(ctx, query, parentPath, FileTypeFolder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query subfolders: %w", err)
 	}
@@ -1398,12 +1353,8 @@ func (d *Database) GetSubfolders(ctx context.Context, parentPath string) ([]Medi
 }
 
 // GetAllMediaFiles returns all media files (images, videos, folders) for thumbnail rebuilding.
-// This method uses its own context as it's typically called from non-HTTP contexts.
 func (d *Database) GetAllMediaFiles() ([]MediaFile, error) {
 	done := observeQuery("get_all_media_files")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -1415,7 +1366,7 @@ func (d *Database) GetAllMediaFiles() ([]MediaFile, error) {
 		ORDER BY path
 	`
 
-	rows, err := d.db.QueryContext(ctx, query, FileTypeImage, FileTypeVideo, FileTypeFolder)
+	rows, err := d.reader.QueryContext(ctx, query, FileTypeImage, FileTypeVideo, FileTypeFolder)
 	if err != nil {
 		done(err)
 		return nil, fmt.Errorf("failed to query media files: %w", err)
@@ -1465,13 +1416,8 @@ func (d *Database) GetAllMediaFiles() ([]MediaFile, error) {
 }
 
 // GetAllMediaFilesForThumbnails returns all media files ordered by path depth (root first).
-// This ensures parent folders are processed before children.
-// This method uses its own context as it's typically called from non-HTTP contexts.
 func (d *Database) GetAllMediaFilesForThumbnails() ([]MediaFile, error) {
 	done := observeQuery("get_all_media_files_for_thumbnails")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
@@ -1485,7 +1431,7 @@ func (d *Database) GetAllMediaFilesForThumbnails() ([]MediaFile, error) {
 			path ASC
 	`
 
-	rows, err := d.db.QueryContext(ctx, query, FileTypeFolder, FileTypeImage, FileTypeVideo)
+	rows, err := d.reader.QueryContext(ctx, query, FileTypeFolder, FileTypeImage, FileTypeVideo)
 	if err != nil {
 		done(err)
 		return nil, fmt.Errorf("failed to query media files: %w", err)
@@ -1535,12 +1481,8 @@ func (d *Database) GetAllMediaFilesForThumbnails() ([]MediaFile, error) {
 }
 
 // GetFilesUpdatedSince returns media files updated after the given timestamp.
-// This is used for incremental thumbnail generation.
 func (d *Database) GetFilesUpdatedSince(ctx context.Context, since time.Time) ([]MediaFile, error) {
 	done := observeQuery("get_files_updated_since")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -1558,7 +1500,7 @@ func (d *Database) GetFilesUpdatedSince(ctx context.Context, since time.Time) ([
 		ORDER BY path
 	`
 
-	rows, err := d.db.QueryContext(ctx, query, FileTypeImage, FileTypeVideo, FileTypeFolder, sinceTimestamp)
+	rows, err := d.reader.QueryContext(ctx, query, FileTypeImage, FileTypeVideo, FileTypeFolder, sinceTimestamp)
 	if err != nil {
 		done(err)
 		return nil, fmt.Errorf("failed to query updated files: %w", err)
@@ -1602,12 +1544,8 @@ func (d *Database) GetFilesUpdatedSince(ctx context.Context, since time.Time) ([
 }
 
 // GetFoldersWithUpdatedContents returns folders that contain files updated after the given timestamp.
-// This includes folders at any level of the hierarchy above the changed files.
 func (d *Database) GetFoldersWithUpdatedContents(ctx context.Context, since time.Time) ([]MediaFile, error) {
 	done := observeQuery("get_folders_with_updated_contents")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -1643,7 +1581,7 @@ func (d *Database) GetFoldersWithUpdatedContents(ctx context.Context, since time
 	ORDER BY LENGTH(f.path) DESC, f.path
 `
 
-	rows, err := d.db.QueryContext(ctx, query, sinceTimestamp, FileTypeFolder)
+	rows, err := d.reader.QueryContext(ctx, query, sinceTimestamp, FileTypeFolder)
 	if err != nil {
 		done(err)
 		return nil, fmt.Errorf("failed to query folders with updated contents: %w", err)
@@ -1667,25 +1605,13 @@ func (d *Database) GetFoldersWithUpdatedContents(ctx context.Context, since time
 }
 
 // GetAllIndexedPaths returns all file paths currently in the index.
-// Used for orphan thumbnail detection.
-// Optimized with covering index (type, path) and pre-allocated map to handle large libraries efficiently.
-// GetAllIndexedPaths returns all file paths currently in the index.
-// Used for orphan thumbnail detection.
 func (d *Database) GetAllIndexedPaths(ctx context.Context) (map[string]struct{}, error) {
 	done := observeQuery("get_all_indexed_paths")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	// Single query — no separate COUNT(*) pre-query.
-	// Use NOT IN to exclude the minority types rather than IN for the majority,
-	// which helps SQLite choose a more efficient query plan (simple scan vs.
-	// multi-range index merge). Adjust the excluded type(s) to match your schema.
-	// If 'playlist' is the only non-media type, this is significantly faster.
-	rows, err := d.db.QueryContext(ctx,
+	rows, err := d.reader.QueryContext(ctx,
 		"SELECT path FROM files WHERE type != ?",
 		FileTypePlaylist,
 	)
@@ -1699,9 +1625,6 @@ func (d *Database) GetAllIndexedPaths(ctx context.Context) (map[string]struct{},
 		}
 	}()
 
-	// Pre-allocate generously — avoids repeated map growth and rehashing.
-	// 50000 is a reasonable upper estimate; over-allocating a map is cheap
-	// compared to the cost of growing it multiple times.
 	paths := make(map[string]struct{}, 50000)
 	var path string
 	for rows.Next() {
@@ -1757,7 +1680,6 @@ func (d *Database) scanMediaFiles(rows *sql.Rows) ([]MediaFile, error) {
 }
 
 // parseTagFilters extracts tag:name and -tag:name patterns from a query
-// Returns the remaining query text and the list of tag filters
 func parseTagFilters(query string) (string, []TagFilter) {
 	var filters []TagFilter
 	result := strings.Builder{}
@@ -1793,7 +1715,6 @@ func skipWhitespace(s string, pos int) int {
 }
 
 // tryParseTagPattern attempts to parse a tag pattern at the given position
-// Returns the tag filter, new position, and whether a pattern was found
 func tryParseTagPattern(s string, pos int) (TagFilter, int, bool) {
 	if pos+8 <= len(s) && strings.ToLower(s[pos:pos+8]) == "not tag:" {
 		tagName := extractTagName(s, pos+8)
@@ -1820,7 +1741,6 @@ func extractTagName(s string, start int) string {
 }
 
 // addWordToResult adds the next word from the query to the result builder
-// Returns the new position after the word
 func addWordToResult(result *strings.Builder, s string, pos int) int {
 	wordEnd := pos
 	for wordEnd < len(s) && s[wordEnd] != ' ' {
@@ -1833,7 +1753,7 @@ func addWordToResult(result *strings.Builder, s string, pos int) int {
 	return wordEnd
 }
 
-// findTagEnd finds where a tag name ends by looking for the next tag pattern or end of string
+// findTagEnd finds where a tag name ends
 func findTagEnd(s string, start int) int {
 	end := start
 	for end < len(s) {

--- a/internal/database/queries_benchmark_test.go
+++ b/internal/database/queries_benchmark_test.go
@@ -35,7 +35,7 @@ func setupBenchmarkDatabase(b *testing.B, fileCount int, favoriteRatio float64, 
 	}
 
 	// Create files
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		b.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -54,12 +54,12 @@ func setupBenchmarkDatabase(b *testing.B, fileCount int, favoriteRatio float64, 
 			MimeType:   "image/jpeg",
 		}
 
-		if err := db.UpsertFile(ctx, tx, &file); err != nil {
+		if err := batch.UpsertFile(ctx, &file); err != nil {
 			b.Fatalf("Failed to upsert file: %v", err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		b.Fatalf("Failed to end batch: %v", err)
 	}
 
@@ -385,7 +385,7 @@ func setupBenchmarkDatabaseWithDirs(b *testing.B, filesPerDir, numDirs int, favo
 	}
 
 	// Create files in multiple directories
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		b.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -404,7 +404,7 @@ func setupBenchmarkDatabaseWithDirs(b *testing.B, filesPerDir, numDirs int, favo
 			Size:       0,
 			ModTime:    time.Now(),
 		}
-		if err := db.UpsertFile(ctx, tx, &folder); err != nil {
+		if err := batch.UpsertFile(ctx, &folder); err != nil {
 			b.Fatalf("Failed to upsert folder: %v", err)
 		}
 
@@ -423,7 +423,7 @@ func setupBenchmarkDatabaseWithDirs(b *testing.B, filesPerDir, numDirs int, favo
 				MimeType:   "image/jpeg",
 			}
 
-			if err := db.UpsertFile(ctx, tx, &file); err != nil {
+			if err := batch.UpsertFile(ctx, &file); err != nil {
 				b.Fatalf("Failed to upsert file: %v", err)
 			}
 
@@ -431,7 +431,7 @@ func setupBenchmarkDatabaseWithDirs(b *testing.B, filesPerDir, numDirs int, favo
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		b.Fatalf("Failed to end batch: %v", err)
 	}
 

--- a/internal/database/queries_integration_performance_test.go
+++ b/internal/database/queries_integration_performance_test.go
@@ -33,7 +33,7 @@ func TestListDirectory_FolderCountPerformanceIntegration(t *testing.T) {
 	// - Each folder has different number of files (0 to 1000)
 	// - Total: ~50,000 files
 	t.Log("Creating test data...")
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestListDirectory_FolderCountPerformanceIntegration(t *testing.T) {
 			Size:       0,
 			ModTime:    time.Now(),
 		}
-		if err := db.UpsertFile(ctx, tx, &folder); err != nil {
+		if err := batch.UpsertFile(ctx, &folder); err != nil {
 			t.Fatalf("Failed to upsert folder: %v", err)
 		}
 
@@ -65,13 +65,13 @@ func TestListDirectory_FolderCountPerformanceIntegration(t *testing.T) {
 				ModTime:    time.Now(),
 				MimeType:   "image/jpeg",
 			}
-			if err := db.UpsertFile(ctx, tx, &file); err != nil {
+			if err := batch.UpsertFile(ctx, &file); err != nil {
 				t.Fatalf("Failed to upsert file: %v", err)
 			}
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("Failed to end batch: %v", err)
 	}
 
@@ -173,7 +173,7 @@ func TestGetMediaInDirectory_PerformanceIntegration(t *testing.T) {
 
 	// Create a large directory with many tagged files
 	t.Log("Creating 5000 files with tags and favorites...")
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -189,12 +189,12 @@ func TestGetMediaInDirectory_PerformanceIntegration(t *testing.T) {
 			ModTime:    time.Now(),
 			MimeType:   "image/jpeg",
 		}
-		if err := db.UpsertFile(ctx, tx, &file); err != nil {
+		if err := batch.UpsertFile(ctx, &file); err != nil {
 			t.Fatalf("Failed to upsert file: %v", err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("Failed to end batch: %v", err)
 	}
 
@@ -289,7 +289,7 @@ func TestPerformanceOptimizations_EndToEnd(t *testing.T) {
 	// Simulate realistic usage: 40,000 files across multiple directories
 	t.Log("Setting up realistic test scenario (40,000 files)...")
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestPerformanceOptimizations_EndToEnd(t *testing.T) {
 			Size:       0,
 			ModTime:    time.Now(),
 		}
-		if err := db.UpsertFile(ctx, tx, &folder); err != nil {
+		if err := batch.UpsertFile(ctx, &folder); err != nil {
 			t.Fatalf("Failed to upsert folder: %v", err)
 		}
 
@@ -331,13 +331,13 @@ func TestPerformanceOptimizations_EndToEnd(t *testing.T) {
 				ModTime:    time.Now(),
 				MimeType:   "image/jpeg",
 			}
-			if err := db.UpsertFile(ctx, tx, &file); err != nil {
+			if err := batch.UpsertFile(ctx, &file); err != nil {
 				t.Fatalf("Failed to upsert file: %v", err)
 			}
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("Failed to end batch: %v", err)
 	}
 
@@ -455,7 +455,7 @@ func TestSlowQueryLogging_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Create enough data to make query take > 1ms
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 	for i := 0; i < 1000; i++ {
 		file := MediaFile{
 			Name:       fmt.Sprintf("file%d.jpg", i),
@@ -466,9 +466,9 @@ func TestSlowQueryLogging_Integration(t *testing.T) {
 			ModTime:    time.Now(),
 			MimeType:   "image/jpeg",
 		}
-		db.UpsertFile(ctx, tx, &file)
+		batch.UpsertFile(ctx, &file)
 	}
-	db.EndBatch(tx, nil)
+	db.EndBatch(batch, nil)
 
 	// This should trigger slow query logging
 	_, err = db.ListDirectory(ctx, ListOptions{

--- a/internal/database/queries_integration_test.go
+++ b/internal/database/queries_integration_test.go
@@ -36,7 +36,7 @@ func TestSearchSuggestionsTagQueries(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -178,7 +178,7 @@ func TestSearchSuggestionsLimitRespected(t *testing.T) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -255,7 +255,7 @@ func TestSearchSuggestionsMixedResults(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -402,7 +402,7 @@ func TestPerformRegularSearchDistribution(t *testing.T) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 

--- a/internal/database/queries_memory_benchmark_test.go
+++ b/internal/database/queries_memory_benchmark_test.go
@@ -96,7 +96,7 @@ func setupGetAllFilesBenchmark(b *testing.B, fileCount int) (db *Database, clean
 	filesPerDir := fileCount / dirCount
 
 	ctx := context.Background()
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		b.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -118,13 +118,13 @@ func setupGetAllFilesBenchmark(b *testing.B, fileCount int) (db *Database, clean
 				MimeType:   "image/jpeg",
 			}
 
-			if err := db.UpsertFile(ctx, tx, &file); err != nil {
+			if err := batch.UpsertFile(ctx, &file); err != nil {
 				b.Fatalf("Failed to upsert file: %v", err)
 			}
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		b.Fatalf("Failed to end batch: %v", err)
 	}
 

--- a/internal/database/queries_optimization_test.go
+++ b/internal/database/queries_optimization_test.go
@@ -30,16 +30,16 @@ func TestGetMediaInDirectoryWithFavoritesAndTags(t *testing.T) {
 	}
 
 	// Insert files
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 	for i := range files {
-		if err := db.UpsertFile(ctx, tx, &files[i]); err != nil {
+		if err := batch.UpsertFile(ctx, &files[i]); err != nil {
 			t.Fatalf("UpsertFile failed: %v", err)
 		}
 	}
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 
@@ -177,7 +177,7 @@ func TestGetMediaInDirectorySorting(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -297,7 +297,7 @@ func TestGetMediaInDirectoryOnlyFolders(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -334,9 +334,9 @@ func TestGetMediaInDirectoryManyTags(t *testing.T) {
 		MimeType:   "image/jpeg",
 	}
 
-	tx, _ := db.BeginBatch(ctx)
-	_ = db.UpsertFile(ctx, tx, &file)
-	_ = db.EndBatch(tx, nil)
+	batch, _ := db.BeginBatch(ctx)
+	_ = batch.UpsertFile(ctx, &file)
+	_ = db.EndBatch(batch, nil)
 
 	// Add many tags (10 tags)
 	tagNames := []string{"tag1", "tag2", "tag3", "tag4", "tag5", "tag6", "tag7", "tag8", "tag9", "tag10"}
@@ -388,7 +388,7 @@ func TestGetMediaInDirectoryLargeDataset(t *testing.T) {
 
 	// Create 1000 files with varying favorites and tags
 	fileCount := 1000
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 
 	for i := 0; i < fileCount; i++ {
 		file := MediaFile{
@@ -400,9 +400,9 @@ func TestGetMediaInDirectoryLargeDataset(t *testing.T) {
 			ModTime:    time.Now(),
 			MimeType:   "image/jpeg",
 		}
-		_ = db.UpsertFile(ctx, tx, &file)
+		_ = batch.UpsertFile(ctx, &file)
 	}
-	_ = db.EndBatch(tx, nil)
+	_ = db.EndBatch(batch, nil)
 
 	// Add some favorites and tags
 	tag1, _ := db.GetOrCreateTag(ctx, "test-tag")
@@ -470,7 +470,7 @@ func TestGetMediaInDirectoryDefaultParameters(t *testing.T) {
 
 	tx, _ := db.BeginBatch(ctx)
 	for i := range files {
-		_ = db.UpsertFile(ctx, tx, &files[i])
+		_ = tx.UpsertFile(ctx, &files[i])
 	}
 	_ = db.EndBatch(tx, nil)
 

--- a/internal/database/queries_performance_test.go
+++ b/internal/database/queries_performance_test.go
@@ -158,7 +158,7 @@ func BenchmarkListDirectory_WithFolderCounts(b *testing.B) {
 
 	// Create a directory structure with many folders
 	// 100 folders in the root, each with varying number of files
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		b.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -173,7 +173,7 @@ func BenchmarkListDirectory_WithFolderCounts(b *testing.B) {
 			Size:       0,
 			ModTime:    time.Now(),
 		}
-		if err := db.UpsertFile(ctx, tx, &folder); err != nil {
+		if err := batch.UpsertFile(ctx, &folder); err != nil {
 			b.Fatalf("Failed to upsert folder: %v", err)
 		}
 
@@ -190,13 +190,13 @@ func BenchmarkListDirectory_WithFolderCounts(b *testing.B) {
 				ModTime:    time.Now(),
 				MimeType:   "image/jpeg",
 			}
-			if err := db.UpsertFile(ctx, tx, &file); err != nil {
+			if err := batch.UpsertFile(ctx, &file); err != nil {
 				b.Fatalf("Failed to upsert file: %v", err)
 			}
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		b.Fatalf("Failed to end batch: %v", err)
 	}
 
@@ -239,7 +239,7 @@ func BenchmarkListDirectory_LargeFolderCounts(b *testing.B) {
 
 	// Create a directory structure simulating real-world usage
 	// 500 folders with varying sizes, some very large
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		b.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -254,7 +254,7 @@ func BenchmarkListDirectory_LargeFolderCounts(b *testing.B) {
 			Size:       0,
 			ModTime:    time.Now(),
 		}
-		if err := db.UpsertFile(ctx, tx, &folder); err != nil {
+		if err := batch.UpsertFile(ctx, &folder); err != nil {
 			b.Fatalf("Failed to upsert folder: %v", err)
 		}
 
@@ -277,13 +277,13 @@ func BenchmarkListDirectory_LargeFolderCounts(b *testing.B) {
 				ModTime:    time.Now(),
 				MimeType:   "image/jpeg",
 			}
-			if err := db.UpsertFile(ctx, tx, &file); err != nil {
+			if err := batch.UpsertFile(ctx, &file); err != nil {
 				b.Fatalf("Failed to upsert file: %v", err)
 			}
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		b.Fatalf("Failed to end batch: %v", err)
 	}
 
@@ -352,7 +352,7 @@ func BenchmarkGetMediaInDirectory_WithManyTags(b *testing.B) {
 	}
 
 	// Create files
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		b.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -368,12 +368,12 @@ func BenchmarkGetMediaInDirectory_WithManyTags(b *testing.B) {
 			ModTime:    time.Now(),
 			MimeType:   "image/jpeg",
 		}
-		if err := db.UpsertFile(ctx, tx, &file); err != nil {
+		if err := batch.UpsertFile(ctx, &file); err != nil {
 			b.Fatalf("Failed to upsert file: %v", err)
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		b.Fatalf("Failed to end batch: %v", err)
 	}
 
@@ -430,7 +430,7 @@ func TestListDirectory_FolderCountAccuracy(t *testing.T) {
 	// folder3/ (empty)
 	// folder4/ (1 file)
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -455,7 +455,7 @@ func TestListDirectory_FolderCountAccuracy(t *testing.T) {
 			Size:       0,
 			ModTime:    time.Now(),
 		}
-		if err := db.UpsertFile(ctx, tx, &f); err != nil {
+		if err := batch.UpsertFile(ctx, &f); err != nil {
 			t.Fatalf("Failed to upsert folder: %v", err)
 		}
 
@@ -471,13 +471,13 @@ func TestListDirectory_FolderCountAccuracy(t *testing.T) {
 				ModTime:    time.Now(),
 				MimeType:   "image/jpeg",
 			}
-			if err := db.UpsertFile(ctx, tx, &file); err != nil {
+			if err := batch.UpsertFile(ctx, &file); err != nil {
 				t.Fatalf("Failed to upsert file: %v", err)
 			}
 		}
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("Failed to end batch: %v", err)
 	}
 

--- a/internal/database/tags.go
+++ b/internal/database/tags.go
@@ -18,19 +18,15 @@ func (d *Database) GetOrCreateTag(ctx context.Context, name string) (*Tag, error
 		return nil, errors.New("tag name cannot be empty")
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Try to get existing tag
+	// Try reader first
 	var tag Tag
 	var createdAt int64
 	var color sql.NullString
 
-	err := d.db.QueryRowContext(ctx,
+	err := d.reader.QueryRowContext(ctx,
 		"SELECT id, name, color, created_at FROM tags WHERE name = ? COLLATE NOCASE",
 		name,
 	).Scan(&tag.ID, &tag.Name, &color, &createdAt)
@@ -43,8 +39,8 @@ func (d *Database) GetOrCreateTag(ctx context.Context, name string) (*Tag, error
 		return &tag, nil
 	}
 
-	// Create new tag
-	result, err := d.db.ExecContext(ctx,
+	// Create via writer
+	result, err := d.writer.ExecContext(ctx,
 		"INSERT INTO tags (name) VALUES (?)",
 		name,
 	)
@@ -70,23 +66,24 @@ func (d *Database) AddTagToFile(ctx context.Context, filePath, tagName string) e
 		return err
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Get or create tag within the same lock
+	tx, err := d.writer.BeginTx(ctx, nil)
+	if err != nil {
+		done(err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
 	var tagID int64
-	err := d.db.QueryRowContext(ctx,
+	err = tx.QueryRowContext(ctx,
 		"SELECT id FROM tags WHERE name = ? COLLATE NOCASE",
 		tagName,
 	).Scan(&tagID)
 
 	if err != nil {
-		// Create new tag
-		result, createErr := d.db.ExecContext(ctx, "INSERT INTO tags (name) VALUES (?)", tagName)
+		result, createErr := tx.ExecContext(ctx, "INSERT INTO tags (name) VALUES (?)", tagName)
 		if createErr != nil {
 			err = fmt.Errorf("failed to create tag: %w", createErr)
 			done(err)
@@ -95,26 +92,32 @@ func (d *Database) AddTagToFile(ctx context.Context, filePath, tagName string) e
 		tagID, _ = result.LastInsertId()
 	}
 
-	_, err = d.db.ExecContext(ctx,
+	_, err = tx.ExecContext(ctx,
 		"INSERT OR IGNORE INTO file_tags (file_path, tag_id) VALUES (?, ?)",
 		filePath, tagID,
 	)
-	done(err)
-	return err
+	if err != nil {
+		done(err)
+		return err
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		done(commitErr)
+		return commitErr
+	}
+
+	done(nil)
+	return nil
 }
 
 // RemoveTagFromFile removes a tag from a file.
 func (d *Database) RemoveTagFromFile(ctx context.Context, filePath, tagName string) error {
 	done := observeQuery("remove_tag_from_file")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(ctx, `
+	_, err := d.writer.ExecContext(ctx, `
 		DELETE FROM file_tags
 		WHERE file_path = ? AND tag_id = (SELECT id FROM tags WHERE name = ? COLLATE NOCASE)
 	`, filePath, tagName)
@@ -125,20 +128,10 @@ func (d *Database) RemoveTagFromFile(ctx context.Context, filePath, tagName stri
 
 // GetFileTags returns all tags for a file.
 func (d *Database) GetFileTags(ctx context.Context, filePath string) ([]string, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	return d.getFileTagsUnlocked(ctx, filePath)
-}
-
-// getFileTagsUnlocked returns tags without acquiring lock.
-// Caller must hold at least a read lock.
-func (d *Database) getFileTagsUnlocked(ctx context.Context, filePath string) ([]string, error) {
-	rows, err := d.db.QueryContext(ctx, `
+	rows, err := d.reader.QueryContext(ctx, `
 		SELECT t.name
 		FROM tags t
 		INNER JOIN file_tags ft ON t.id = ft.tag_id
@@ -169,14 +162,10 @@ func (d *Database) getFileTagsUnlocked(ctx context.Context, filePath string) ([]
 func (d *Database) SetFileTags(ctx context.Context, filePath string, tagNames []string) error {
 	done := observeQuery("set_file_tags")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := d.writer.BeginTx(ctx, nil)
 	if err != nil {
 		done(err)
 		return err
@@ -191,25 +180,21 @@ func (d *Database) SetFileTags(ctx context.Context, filePath string, tagNames []
 		}
 	}()
 
-	// Remove existing tags
 	_, err = tx.ExecContext(ctx, "DELETE FROM file_tags WHERE file_path = ?", filePath)
 	if err != nil {
 		done(err)
 		return err
 	}
 
-	// Add new tags
 	for _, tagName := range tagNames {
 		tagName = strings.TrimSpace(tagName)
 		if tagName == "" {
 			continue
 		}
 
-		// Get or create tag
 		var tagID int64
 		err = tx.QueryRowContext(ctx, "SELECT id FROM tags WHERE name = ? COLLATE NOCASE", tagName).Scan(&tagID)
 		if err != nil {
-			// Create tag
 			result, createErr := tx.ExecContext(ctx, "INSERT INTO tags (name) VALUES (?)", tagName)
 			if createErr != nil {
 				err = createErr
@@ -219,7 +204,6 @@ func (d *Database) SetFileTags(ctx context.Context, filePath string, tagNames []
 			tagID, _ = result.LastInsertId()
 		}
 
-		// Add relationship
 		_, err = tx.ExecContext(ctx,
 			"INSERT OR IGNORE INTO file_tags (file_path, tag_id) VALUES (?, ?)",
 			filePath, tagID,
@@ -243,14 +227,10 @@ func (d *Database) SetFileTags(ctx context.Context, filePath string, tagNames []
 func (d *Database) GetAllTags(ctx context.Context) ([]Tag, error) {
 	done := observeQuery("get_all_tags")
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	rows, err := d.db.QueryContext(ctx, `
+	rows, err := d.reader.QueryContext(ctx, `
 		SELECT t.id, t.name, t.color, t.created_at, COUNT(ft.id) as item_count
 		FROM tags t
 		LEFT JOIN file_tags ft ON t.id = ft.tag_id
@@ -303,16 +283,11 @@ func (d *Database) GetFilesByTag(ctx context.Context, tagName string, page, page
 		pageSize = 200
 	}
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	// Get total count
 	var totalItems int
-	err := d.db.QueryRowContext(ctx, `
+	err := d.reader.QueryRowContext(ctx, `
 		SELECT COUNT(DISTINCT ft.file_path)
 		FROM file_tags ft
 		INNER JOIN tags t ON ft.tag_id = t.id
@@ -329,9 +304,13 @@ func (d *Database) GetFilesByTag(ctx context.Context, tagName string, page, page
 	}
 	offset := (page - 1) * pageSize
 
-	// Get files
-	rows, err := d.db.QueryContext(ctx, `
-		SELECT f.id, f.name, f.path, f.parent_path, f.type, f.size, f.mod_time, f.mime_type
+	rows, err := d.reader.QueryContext(ctx, `
+		SELECT f.id, f.name, f.path, f.parent_path, f.type, f.size, f.mod_time, f.mime_type,
+		       EXISTS(SELECT 1 FROM favorites WHERE path = f.path) AS is_favorite,
+		       (SELECT GROUP_CONCAT(t2.name, ',')
+		        FROM file_tags ft2
+		        JOIN tags t2 ON ft2.tag_id = t2.id
+		        WHERE ft2.file_path = f.path) AS tags
 		FROM files f
 		INNER JOIN file_tags ft ON f.path = ft.file_path
 		INNER JOIN tags t ON ft.tag_id = t.id
@@ -354,10 +333,13 @@ func (d *Database) GetFilesByTag(ctx context.Context, tagName string, page, page
 		var file MediaFile
 		var modTime int64
 		var mimeType sql.NullString
+		var isFavorite int
+		var tagsString sql.NullString
 
 		if err := rows.Scan(
 			&file.ID, &file.Name, &file.Path, &file.ParentPath,
 			&file.Type, &file.Size, &modTime, &mimeType,
+			&isFavorite, &tagsString,
 		); err != nil {
 			continue
 		}
@@ -371,10 +353,11 @@ func (d *Database) GetFilesByTag(ctx context.Context, tagName string, page, page
 			file.ThumbnailURL = "/api/thumbnail/" + file.Path
 		}
 
-		// Use unlocked versions since we already hold the lock
-		tags, _ := d.getFileTagsUnlocked(ctx, file.Path)
-		file.Tags = tags
-		file.IsFavorite = d.isFavoriteUnlocked(ctx, file.Path)
+		file.IsFavorite = isFavorite == 1
+
+		if tagsString.Valid && tagsString.String != "" {
+			file.Tags = strings.Split(tagsString.String, ",")
+		}
 
 		items = append(items, file)
 	}
@@ -394,14 +377,10 @@ func (d *Database) GetFilesByTag(ctx context.Context, tagName string, page, page
 func (d *Database) DeleteTag(ctx context.Context, tagName string) error {
 	done := observeQuery("delete_tag")
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(ctx, "DELETE FROM tags WHERE name = ? COLLATE NOCASE", tagName)
+	_, err := d.writer.ExecContext(ctx, "DELETE FROM tags WHERE name = ? COLLATE NOCASE", tagName)
 	done(err)
 	return err
 }
@@ -417,15 +396,10 @@ func (d *Database) RenameTag(ctx context.Context, oldName, newName string) error
 		return err
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(
-		ctx,
+	_, err := d.writer.ExecContext(ctx,
 		"UPDATE tags SET name = ? WHERE name = ? COLLATE NOCASE",
 		newName, oldName,
 	)
@@ -435,15 +409,10 @@ func (d *Database) RenameTag(ctx context.Context, oldName, newName string) error
 
 // SetTagColor sets the color for a tag.
 func (d *Database) SetTagColor(ctx context.Context, tagName, color string) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Use passed context with timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(
-		ctx,
+	_, err := d.writer.ExecContext(ctx,
 		"UPDATE tags SET color = ? WHERE name = ? COLLATE NOCASE",
 		color, tagName,
 	)
@@ -452,14 +421,11 @@ func (d *Database) SetTagColor(ctx context.Context, tagName, color string) error
 
 // GetTagCount returns the total number of tags.
 func (d *Database) GetTagCount(ctx context.Context) int {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var count int
-	if err := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM tags").Scan(&count); err != nil {
+	if err := d.reader.QueryRowContext(ctx, "SELECT COUNT(*) FROM tags").Scan(&count); err != nil {
 		return 0
 	}
 	return count
@@ -476,21 +442,16 @@ type TagWithCount struct {
 func (d *Database) GetAllTagsWithCounts(ctx context.Context) ([]TagWithCount, error) {
 	done := observeQuery("get_all_tags_with_counts")
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	query := `
+	rows, err := d.reader.QueryContext(ctx, `
 		SELECT t.name, COALESCE(t.color, ''), COUNT(ft.id) as count
 		FROM tags t
 		LEFT JOIN file_tags ft ON t.id = ft.tag_id
 		GROUP BY t.id, t.name, t.color
 		ORDER BY count DESC, t.name COLLATE NOCASE
-	`
-
-	rows, err := d.db.QueryContext(ctx, query)
+	`)
 	if err != nil {
 		done(err)
 		return nil, err
@@ -520,21 +481,16 @@ func (d *Database) GetAllTagsWithCounts(ctx context.Context) ([]TagWithCount, er
 func (d *Database) GetUnusedTags(ctx context.Context) ([]string, error) {
 	done := observeQuery("get_unused_tags")
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	query := `
+	rows, err := d.reader.QueryContext(ctx, `
 		SELECT t.name
 		FROM tags t
 		LEFT JOIN file_tags ft ON t.id = ft.tag_id
 		WHERE ft.id IS NULL
 		ORDER BY t.name COLLATE NOCASE
-	`
-
-	rows, err := d.db.QueryContext(ctx, query)
+	`)
 	if err != nil {
 		done(err)
 		return nil, err
@@ -573,40 +529,31 @@ func (d *Database) RenameTagEverywhere(ctx context.Context, oldName, newName str
 		return 0, err
 	}
 
-	// Allow case-only changes, only skip if names are exactly identical
 	if oldName == newName {
 		done(nil)
-		return 0, nil // No change needed
+		return 0, nil
 	}
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Start transaction
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := d.writer.BeginTx(ctx, nil)
 	if err != nil {
 		done(err)
 		return 0, err
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Check if new tag name already exists
 	var existingID int64
 	err = tx.QueryRowContext(ctx,
-		"SELECT id FROM tags WHERE name = ? COLLATE NOCASE",
-		newName,
+		"SELECT id FROM tags WHERE name = ? COLLATE NOCASE", newName,
 	).Scan(&existingID)
 
 	switch {
 	case err == nil:
-		// Target tag exists, check if it's the same tag (case-only change)
 		var oldID int64
 		err = tx.QueryRowContext(ctx,
-			"SELECT id FROM tags WHERE name = ? COLLATE NOCASE",
-			oldName,
+			"SELECT id FROM tags WHERE name = ? COLLATE NOCASE", oldName,
 		).Scan(&oldID)
 		if err != nil {
 			err = fmt.Errorf("old tag not found: %w", err)
@@ -615,24 +562,16 @@ func (d *Database) RenameTagEverywhere(ctx context.Context, oldName, newName str
 		}
 
 		if existingID == oldID {
-			// Same tag, just update the case
-			_, err = tx.ExecContext(ctx,
-				"UPDATE tags SET name = ? WHERE id = ?",
-				newName, oldID,
-			)
+			_, err = tx.ExecContext(ctx, "UPDATE tags SET name = ? WHERE id = ?", newName, oldID)
 			if err != nil {
 				err = fmt.Errorf("failed to update tag case: %w", err)
 				done(err)
 				return 0, err
 			}
 		} else {
-			// Different tags, we need to merge
-			// Move all file_tags from old tag to new tag (skip duplicates)
 			_, err = tx.ExecContext(ctx, `
 				INSERT OR IGNORE INTO file_tags (file_path, tag_id, created_at)
-				SELECT file_path, ?, created_at
-				FROM file_tags
-				WHERE tag_id = ?
+				SELECT file_path, ?, created_at FROM file_tags WHERE tag_id = ?
 			`, existingID, oldID)
 			if err != nil {
 				err = fmt.Errorf("failed to merge file tags: %w", err)
@@ -640,11 +579,7 @@ func (d *Database) RenameTagEverywhere(ctx context.Context, oldName, newName str
 				return 0, err
 			}
 
-			// Delete old tag (cascade will remove old file_tags)
-			_, err = tx.ExecContext(ctx,
-				"DELETE FROM tags WHERE id = ?",
-				oldID,
-			)
+			_, err = tx.ExecContext(ctx, "DELETE FROM tags WHERE id = ?", oldID)
 			if err != nil {
 				err = fmt.Errorf("failed to delete old tag: %w", err)
 				done(err)
@@ -652,10 +587,8 @@ func (d *Database) RenameTagEverywhere(ctx context.Context, oldName, newName str
 			}
 		}
 	case errors.Is(err, sql.ErrNoRows):
-		// Target tag doesn't exist, simple rename
 		_, err = tx.ExecContext(ctx,
-			"UPDATE tags SET name = ? WHERE name = ? COLLATE NOCASE",
-			newName, oldName,
+			"UPDATE tags SET name = ? WHERE name = ? COLLATE NOCASE", newName, oldName,
 		)
 		if err != nil {
 			err = fmt.Errorf("failed to rename tag: %w", err)
@@ -667,7 +600,6 @@ func (d *Database) RenameTagEverywhere(ctx context.Context, oldName, newName str
 		return 0, err
 	}
 
-	// Get count of affected files
 	var count int
 	err = tx.QueryRowContext(ctx, `
 		SELECT COUNT(DISTINCT ft.file_path)
@@ -681,7 +613,6 @@ func (d *Database) RenameTagEverywhere(ctx context.Context, oldName, newName str
 		return 0, err
 	}
 
-	// Commit transaction
 	if err := tx.Commit(); err != nil {
 		done(err)
 		return 0, err
@@ -703,21 +634,16 @@ func (d *Database) DeleteTagEverywhere(ctx context.Context, tagName string) (int
 		return 0, err
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Start transaction
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := d.writer.BeginTx(ctx, nil)
 	if err != nil {
 		done(err)
 		return 0, err
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Get count of affected files before deletion
 	var count int
 	err = tx.QueryRowContext(ctx, `
 		SELECT COUNT(DISTINCT ft.file_path)
@@ -731,10 +657,8 @@ func (d *Database) DeleteTagEverywhere(ctx context.Context, tagName string) (int
 		return 0, err
 	}
 
-	// Delete the tag (CASCADE will remove file_tags)
 	result, err := tx.ExecContext(ctx,
-		"DELETE FROM tags WHERE name = ? COLLATE NOCASE",
-		tagName,
+		"DELETE FROM tags WHERE name = ? COLLATE NOCASE", tagName,
 	)
 	if err != nil {
 		err = fmt.Errorf("failed to delete tag: %w", err)
@@ -749,7 +673,6 @@ func (d *Database) DeleteTagEverywhere(ctx context.Context, tagName string) (int
 		return 0, err
 	}
 
-	// Commit transaction
 	if err := tx.Commit(); err != nil {
 		done(err)
 		return 0, err
@@ -760,10 +683,7 @@ func (d *Database) DeleteTagEverywhere(ctx context.Context, tagName string) (int
 	return count, nil
 }
 
-// BulkAddTagsToFiles adds one or more tags to multiple files in a single transaction.
-// This replaces the previous pattern of calling AddTagToFile in a loop per path per tag,
-// reducing N*M individual lock/transaction cycles to a single transaction with prepared
-// statements.
+// BulkAddTagsToFiles adds tags to multiple files in a single transaction.
 func (d *Database) BulkAddTagsToFiles(ctx context.Context, filePaths, tagNames []string) (int, []error, error) {
 	done := observeQuery("bulk_add_tags_to_files")
 
@@ -772,13 +692,10 @@ func (d *Database) BulkAddTagsToFiles(ctx context.Context, filePaths, tagNames [
 		return 0, nil, nil
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := d.writer.BeginTx(ctx, nil)
 	if err != nil {
 		done(err)
 		return 0, nil, fmt.Errorf("failed to begin transaction: %w", err)
@@ -793,14 +710,12 @@ func (d *Database) BulkAddTagsToFiles(ctx context.Context, filePaths, tagNames [
 		}
 	}()
 
-	// Resolve all tag IDs upfront — create any that don't exist.
 	tagIDs, err := resolveTagIDs(ctx, tx, tagNames, true)
 	if err != nil {
 		done(err)
 		return 0, nil, err
 	}
 
-	// Prepare the association insert once — reused for all path×tag combinations
 	assocStmt, err := tx.PrepareContext(ctx,
 		"INSERT OR IGNORE INTO file_tags (file_path, tag_id) VALUES (?, ?)",
 	)
@@ -810,7 +725,6 @@ func (d *Database) BulkAddTagsToFiles(ctx context.Context, filePaths, tagNames [
 	}
 	defer func() { _ = assocStmt.Close() }()
 
-	// Apply all tags to all files
 	successCount := 0
 	var errs []error
 
@@ -841,7 +755,7 @@ func (d *Database) BulkAddTagsToFiles(ctx context.Context, filePaths, tagNames [
 	return successCount, errs, nil
 }
 
-// BulkRemoveTagsFromFiles removes one or more tags from multiple files in a single transaction.
+// BulkRemoveTagsFromFiles removes tags from multiple files in a single transaction.
 func (d *Database) BulkRemoveTagsFromFiles(ctx context.Context, filePaths, tagNames []string) (int, []error, error) {
 	done := observeQuery("bulk_remove_tags_from_files")
 
@@ -850,13 +764,10 @@ func (d *Database) BulkRemoveTagsFromFiles(ctx context.Context, filePaths, tagNa
 		return 0, nil, nil
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := d.writer.BeginTx(ctx, nil)
 	if err != nil {
 		done(err)
 		return 0, nil, fmt.Errorf("failed to begin transaction: %w", err)
@@ -871,7 +782,6 @@ func (d *Database) BulkRemoveTagsFromFiles(ctx context.Context, filePaths, tagNa
 		}
 	}()
 
-	// Resolve tag IDs — don't create missing tags
 	tagIDs, err := resolveTagIDs(ctx, tx, tagNames, false)
 	if err != nil {
 		done(err)
@@ -879,12 +789,10 @@ func (d *Database) BulkRemoveTagsFromFiles(ctx context.Context, filePaths, tagNa
 	}
 
 	if len(tagIDs) == 0 {
-		// None of the tags exist — nothing to do
 		done(nil)
 		return 0, nil, nil
 	}
 
-	// Prepare the delete statement
 	deleteStmt, err := tx.PrepareContext(ctx,
 		"DELETE FROM file_tags WHERE file_path = ? AND tag_id = ?",
 	)
@@ -927,18 +835,12 @@ func (d *Database) BulkRemoveTagsFromFiles(ctx context.Context, filePaths, tagNa
 }
 
 // GetBatchFileTags returns tags for multiple files in a single query.
-// Replaces the pattern of calling GetFileTags N times in a loop,
-// reducing N lock/query cycles to 1.
 func (d *Database) GetBatchFileTags(ctx context.Context, filePaths []string) (map[string][]string, error) {
 	done := observeQuery("get_batch_file_tags")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	// Initialize result with empty slices for all requested paths
 	result := make(map[string][]string, len(filePaths))
 	for _, path := range filePaths {
 		if path != "" {
@@ -951,14 +853,13 @@ func (d *Database) GetBatchFileTags(ctx context.Context, filePaths []string) (ma
 		return result, nil
 	}
 
-	// Build parameterized IN clause safely (placeholders are only "?" literals)
 	inClause, args := buildPlaceholders(filePaths)
 	if inClause == "" {
 		done(nil)
 		return result, nil
 	}
 
-	//nolint:gosec // inClause contains only "?" placeholders generated by buildPlaceholders; no user input is interpolated
+	//nolint:gosec
 	query := `
 		SELECT ft.file_path, t.name
 		FROM file_tags ft
@@ -967,7 +868,7 @@ func (d *Database) GetBatchFileTags(ctx context.Context, filePaths []string) (ma
 		ORDER BY ft.file_path, t.name COLLATE NOCASE
 	`
 
-	rows, err := d.db.QueryContext(ctx, query, args...)
+	rows, err := d.reader.QueryContext(ctx, query, args...)
 	if err != nil {
 		done(err)
 		return nil, fmt.Errorf("batch file tags query failed: %w", err)
@@ -996,9 +897,6 @@ func (d *Database) GetBatchFileTags(ctx context.Context, filePaths []string) (ma
 	return result, nil
 }
 
-// resolveTagIDs looks up or creates tags within an existing transaction,
-// returning their IDs. This is extracted to reduce cognitive complexity
-// of the bulk operation callers.
 func resolveTagIDs(ctx context.Context, tx *sql.Tx, tagNames []string, createMissing bool) ([]int64, error) {
 	selectStmt, err := tx.PrepareContext(ctx,
 		"SELECT id FROM tags WHERE name = ? COLLATE NOCASE",
@@ -1030,13 +928,10 @@ func resolveTagIDs(ctx context.Context, tx *sql.Tx, tagNames []string, createMis
 		err = selectStmt.QueryRowContext(ctx, tagName).Scan(&tagID)
 		if err != nil {
 			if !createMissing {
-				// Tag doesn't exist — skip it
 				continue
 			}
-			// Tag doesn't exist — create it
 			result, createErr := insertStmt.ExecContext(ctx, tagName)
 			if createErr != nil {
-				// Might be a race with UNIQUE constraint; try select again
 				if err2 := selectStmt.QueryRowContext(ctx, tagName).Scan(&tagID); err2 != nil {
 					return nil, fmt.Errorf("failed to create tag %q: %w", tagName, createErr)
 				}
@@ -1050,9 +945,6 @@ func resolveTagIDs(ctx context.Context, tx *sql.Tx, tagNames []string, createMis
 	return tagIDs, nil
 }
 
-// buildPlaceholders generates a parameterized IN clause with the given
-// string values. It returns the placeholder string (e.g. "?,?,?") and
-// the corresponding args. Empty strings are skipped.
 func buildPlaceholders(values []string) (clause string, args []interface{}) {
 	placeholders := make([]string, 0, len(values))
 	args = make([]interface{}, 0, len(values))

--- a/internal/database/tags_integration_test.go
+++ b/internal/database/tags_integration_test.go
@@ -279,7 +279,7 @@ func TestGetFilesByTagIntegration(t *testing.T) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, file)
+		_ = tx.UpsertFile(ctx, file)
 	}
 	_ = db.EndBatch(tx, nil)
 
@@ -334,7 +334,7 @@ func TestGetFilesByTagPaginationIntegration(t *testing.T) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		_ = db.UpsertFile(ctx, tx, file)
+		_ = tx.UpsertFile(ctx, file)
 	}
 	_ = db.EndBatch(tx, nil)
 

--- a/internal/database/webauthn.go
+++ b/internal/database/webauthn.go
@@ -15,13 +15,11 @@ import (
 )
 
 const (
-	// webAuthnUsername is the username for the single-user WebAuthn implementation
-	webAuthnUsername = "user"
-	// webAuthnDisplayName is the display name for the single-user WebAuthn implementation
+	webAuthnUsername    = "user"
 	webAuthnDisplayName = "Media Viewer User"
 )
 
-// WebAuthnCredential represents a stored passkey credential
+// WebAuthnCredential represents a WebAuthn credential record stored in the database.
 type WebAuthnCredential struct {
 	ID              int64     `json:"id"`
 	UserID          int64     `json:"userId"`
@@ -35,43 +33,31 @@ type WebAuthnCredential struct {
 	LastUsedAt      time.Time `json:"lastUsedAt"`
 }
 
-// WebAuthnUser implements webauthn.User interface for our single-user app
+// WebAuthnUser wraps a User and their WebAuthn credentials for authentication.
 type WebAuthnUser struct {
 	user        *User
 	credentials []webauthn.Credential
 }
 
-// WebAuthnID returns the user's ID as bytes
-func (u *WebAuthnUser) WebAuthnID() []byte {
-	return []byte(fmt.Sprintf("%d", u.user.ID))
-}
+// WebAuthnID returns the user's WebAuthn ID.
+func (u *WebAuthnUser) WebAuthnID() []byte { return []byte(fmt.Sprintf("%d", u.user.ID)) }
 
-// WebAuthnName returns a human-readable name
-func (u *WebAuthnUser) WebAuthnName() string {
-	return webAuthnUsername
-}
+// WebAuthnName returns the user's WebAuthn name.
+func (u *WebAuthnUser) WebAuthnName() string { return webAuthnUsername }
 
-// WebAuthnDisplayName returns the display name
-func (u *WebAuthnUser) WebAuthnDisplayName() string {
-	return webAuthnDisplayName
-}
+// WebAuthnDisplayName returns the user's WebAuthn display name.
+func (u *WebAuthnUser) WebAuthnDisplayName() string { return webAuthnDisplayName }
 
-// WebAuthnCredentials returns all credentials for this user
-func (u *WebAuthnUser) WebAuthnCredentials() []webauthn.Credential {
-	return u.credentials
-}
+// WebAuthnCredentials returns the user's WebAuthn credentials.
+func (u *WebAuthnUser) WebAuthnCredentials() []webauthn.Credential { return u.credentials }
 
-// WebAuthnIcon returns an icon URL (deprecated but required by interface)
-func (u *WebAuthnUser) WebAuthnIcon() string {
-	return ""
-}
+// WebAuthnIcon returns the user's WebAuthn icon (empty).
+func (u *WebAuthnUser) WebAuthnIcon() string { return "" }
 
-// GetUser returns the underlying User
-func (u *WebAuthnUser) GetUser() *User {
-	return u.user
-}
+// GetUser returns the underlying User struct.
+func (u *WebAuthnUser) GetUser() *User { return u.user }
 
-// InitWebAuthnSchema adds the WebAuthn tables if they don't exist
+// InitWebAuthnSchema initializes the WebAuthn database schema.
 func (d *Database) InitWebAuthnSchema() error {
 	logging.Debug("Initializing WebAuthn database schema...")
 
@@ -109,7 +95,7 @@ func (d *Database) InitWebAuthnSchema() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	_, err := d.db.ExecContext(ctx, schema)
+	_, err := d.writer.ExecContext(ctx, schema)
 	if err != nil {
 		logging.Error("Failed to initialize WebAuthn schema: %v", err)
 		return err
@@ -119,17 +105,13 @@ func (d *Database) InitWebAuthnSchema() error {
 	return nil
 }
 
-// SaveWebAuthnCredential stores a new passkey credential
+// SaveWebAuthnCredential saves a new WebAuthn credential for a user.
 func (d *Database) SaveWebAuthnCredential(ctx context.Context, userID int64, cred *webauthn.Credential, name string) error {
 	done := observeQuery("save_webauthn_credential")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Serialize transports to JSON
 	var transportsJSON []byte
 	var err error
 	if len(cred.Transport) > 0 {
@@ -146,19 +128,14 @@ func (d *Database) SaveWebAuthnCredential(ctx context.Context, userID int64, cre
 		transportsJSON = []byte("[]")
 	}
 
-	_, err = d.db.ExecContext(ctx, `
+	_, err = d.writer.ExecContext(ctx, `
 		INSERT INTO webauthn_credentials
 		(user_id, credential_id, public_key, attestation_type, aaguid, sign_count, name, transports)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		userID,
-		cred.ID,
-		cred.PublicKey,
-		cred.AttestationType,
-		cred.Authenticator.AAGUID,
-		cred.Authenticator.SignCount,
-		name,
-		string(transportsJSON),
+		userID, cred.ID, cred.PublicKey, cred.AttestationType,
+		cred.Authenticator.AAGUID, cred.Authenticator.SignCount,
+		name, string(transportsJSON),
 	)
 
 	if err != nil {
@@ -172,17 +149,14 @@ func (d *Database) SaveWebAuthnCredential(ctx context.Context, userID int64, cre
 	return nil
 }
 
-// GetWebAuthnCredentials returns all credentials for a user
+// GetWebAuthnCredentials returns all WebAuthn credentials for a user.
 func (d *Database) GetWebAuthnCredentials(ctx context.Context, userID int64) ([]webauthn.Credential, error) {
 	done := observeQuery("get_webauthn_credentials")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	rows, err := d.db.QueryContext(ctx, `
+	rows, err := d.reader.QueryContext(ctx, `
 		SELECT credential_id, public_key, attestation_type, aaguid, sign_count, transports
 		FROM webauthn_credentials
 		WHERE user_id = ?
@@ -204,14 +178,8 @@ func (d *Database) GetWebAuthnCredentials(ctx context.Context, userID int64) ([]
 		var aaguid []byte
 		var transportsJSON sql.NullString
 
-		err := rows.Scan(
-			&cred.ID,
-			&cred.PublicKey,
-			&cred.AttestationType,
-			&aaguid,
-			&cred.Authenticator.SignCount,
-			&transportsJSON,
-		)
+		err := rows.Scan(&cred.ID, &cred.PublicKey, &cred.AttestationType,
+			&aaguid, &cred.Authenticator.SignCount, &transportsJSON)
 		if err != nil {
 			logging.Warn("Failed to scan credential row: %v", err)
 			continue
@@ -220,7 +188,6 @@ func (d *Database) GetWebAuthnCredentials(ctx context.Context, userID int64) ([]
 		cred.Authenticator.AAGUID = aaguid
 		cred.Authenticator.CloneWarning = false
 
-		// Parse transports
 		if transportsJSON.Valid && transportsJSON.String != "" {
 			var transports []string
 			if jsonErr := json.Unmarshal([]byte(transportsJSON.String), &transports); jsonErr == nil {
@@ -243,23 +210,18 @@ func (d *Database) GetWebAuthnCredentials(ctx context.Context, userID int64) ([]
 	return credentials, nil
 }
 
-// GetWebAuthnUser returns a WebAuthnUser for the single user with all their credentials
+// GetWebAuthnUser returns the WebAuthnUser for authentication.
 func (d *Database) GetWebAuthnUser(ctx context.Context) (*WebAuthnUser, error) {
 	done := observeQuery("get_webauthn_user")
-
-	d.mu.RLock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	// Get the single user
 	var user User
 	var createdAt, updatedAt int64
-	err := d.db.QueryRowContext(ctx,
+	err := d.reader.QueryRowContext(ctx,
 		"SELECT id, created_at, updated_at FROM users LIMIT 1",
 	).Scan(&user.ID, &createdAt, &updatedAt)
-
-	d.mu.RUnlock()
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -274,7 +236,6 @@ func (d *Database) GetWebAuthnUser(ctx context.Context) (*WebAuthnUser, error) {
 	user.CreatedAt = time.Unix(createdAt, 0)
 	user.UpdatedAt = time.Unix(updatedAt, 0)
 
-	// Get credentials (separate query to avoid lock issues)
 	credentials, err := d.GetWebAuthnCredentials(ctx, user.ID)
 	if err != nil {
 		logging.Warn("Failed to get credentials for user: %v", err)
@@ -288,17 +249,14 @@ func (d *Database) GetWebAuthnUser(ctx context.Context) (*WebAuthnUser, error) {
 	}, nil
 }
 
-// UpdateCredentialSignCount updates the sign count after successful authentication
+// UpdateCredentialSignCount updates the sign count for a WebAuthn credential.
 func (d *Database) UpdateCredentialSignCount(ctx context.Context, credentialID []byte, signCount uint32) error {
 	done := observeQuery("update_credential_sign_count")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	_, err := d.db.ExecContext(ctx, `
+	_, err := d.writer.ExecContext(ctx, `
 		UPDATE webauthn_credentials
 		SET sign_count = ?, last_used_at = strftime('%s', 'now')
 		WHERE credential_id = ?
@@ -312,17 +270,14 @@ func (d *Database) UpdateCredentialSignCount(ctx context.Context, credentialID [
 	return err
 }
 
-// DeleteWebAuthnCredential removes a passkey
+// DeleteWebAuthnCredential deletes a WebAuthn credential for a user.
 func (d *Database) DeleteWebAuthnCredential(ctx context.Context, userID, credentialID int64) error {
 	done := observeQuery("delete_webauthn_credential")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	result, err := d.db.ExecContext(ctx, `
+	result, err := d.writer.ExecContext(ctx, `
 		DELETE FROM webauthn_credentials WHERE id = ? AND user_id = ?
 	`, credentialID, userID)
 	if err != nil {
@@ -343,17 +298,14 @@ func (d *Database) DeleteWebAuthnCredential(ctx context.Context, userID, credent
 	return nil
 }
 
-// ListWebAuthnCredentials returns credential metadata for display
+// ListWebAuthnCredentials returns all WebAuthnCredential records for a user.
 func (d *Database) ListWebAuthnCredentials(ctx context.Context, userID int64) ([]WebAuthnCredential, error) {
 	done := observeQuery("list_webauthn_credentials")
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	rows, err := d.db.QueryContext(ctx, `
+	rows, err := d.reader.QueryContext(ctx, `
 		SELECT id, user_id, credential_id, name, sign_count, created_at, last_used_at
 		FROM webauthn_credentials
 		WHERE user_id = ?
@@ -375,15 +327,8 @@ func (d *Database) ListWebAuthnCredentials(ctx context.Context, userID int64) ([
 		var cred WebAuthnCredential
 		var createdAt, lastUsedAt int64
 
-		err := rows.Scan(
-			&cred.ID,
-			&cred.UserID,
-			&cred.CredentialID,
-			&cred.Name,
-			&cred.SignCount,
-			&createdAt,
-			&lastUsedAt,
-		)
+		err := rows.Scan(&cred.ID, &cred.UserID, &cred.CredentialID,
+			&cred.Name, &cred.SignCount, &createdAt, &lastUsedAt)
 		if err != nil {
 			logging.Warn("Failed to scan credential metadata: %v", err)
 			continue
@@ -399,19 +344,16 @@ func (d *Database) ListWebAuthnCredentials(ctx context.Context, userID int64) ([
 	return credentials, rowsErr
 }
 
-// SaveWebAuthnSession stores challenge data for WebAuthn ceremonies
+// SaveWebAuthnSession saves a WebAuthn session with a TTL.
 func (d *Database) SaveWebAuthnSession(ctx context.Context, sessionID string, data []byte, ttl time.Duration) error {
 	done := observeQuery("save_webauthn_session")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	expiresAt := time.Now().Add(ttl)
 
-	_, err := d.db.ExecContext(ctx, `
+	_, err := d.writer.ExecContext(ctx, `
 		INSERT OR REPLACE INTO webauthn_sessions (session_id, session_data, expires_at)
 		VALUES (?, ?, ?)
 	`, sessionID, data, expiresAt.Unix())
@@ -424,20 +366,24 @@ func (d *Database) SaveWebAuthnSession(ctx context.Context, sessionID string, da
 	return err
 }
 
-// GetWebAuthnSession retrieves and deletes challenge data
+// GetWebAuthnSession retrieves and deletes a WebAuthn session by ID.
 func (d *Database) GetWebAuthnSession(ctx context.Context, sessionID string) ([]byte, error) {
 	done := observeQuery("get_webauthn_session")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
+	tx, err := d.writer.BeginTx(ctx, nil)
+	if err != nil {
+		done(err)
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
 	var data []byte
 	var expiresAt int64
 
-	err := d.db.QueryRowContext(ctx, `
+	err = tx.QueryRowContext(ctx, `
 		SELECT session_data, expires_at FROM webauthn_sessions WHERE session_id = ?
 	`, sessionID).Scan(&data, &expiresAt)
 	if err != nil {
@@ -451,13 +397,15 @@ func (d *Database) GetWebAuthnSession(ctx context.Context, sessionID string) ([]
 		return nil, fmt.Errorf("failed to get session: %w", err)
 	}
 
-	// Delete the session (one-time use)
-	_, delErr := d.db.ExecContext(ctx, "DELETE FROM webauthn_sessions WHERE session_id = ?", sessionID)
+	_, delErr := tx.ExecContext(ctx, "DELETE FROM webauthn_sessions WHERE session_id = ?", sessionID)
 	if delErr != nil {
 		logging.Warn("Failed to delete WebAuthn session after retrieval: %v", delErr)
 	}
 
-	// Check expiration
+	if commitErr := tx.Commit(); commitErr != nil {
+		logging.Warn("Failed to commit WebAuthn session deletion: %v", commitErr)
+	}
+
 	if time.Now().Unix() > expiresAt {
 		err = fmt.Errorf("session expired")
 		done(err)
@@ -468,17 +416,14 @@ func (d *Database) GetWebAuthnSession(ctx context.Context, sessionID string) ([]
 	return data, nil
 }
 
-// CleanExpiredWebAuthnSessions removes expired challenge sessions
+// CleanExpiredWebAuthnSessions removes expired WebAuthn sessions.
 func (d *Database) CleanExpiredWebAuthnSessions(ctx context.Context) error {
 	done := observeQuery("clean_expired_webauthn_sessions")
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	result, err := d.db.ExecContext(ctx, "DELETE FROM webauthn_sessions WHERE expires_at < ?", time.Now().Unix())
+	result, err := d.writer.ExecContext(ctx, "DELETE FROM webauthn_sessions WHERE expires_at < ?", time.Now().Unix())
 	if err != nil {
 		logging.Error("Failed to clean expired WebAuthn sessions: %v", err)
 		done(err)
@@ -493,16 +438,13 @@ func (d *Database) CleanExpiredWebAuthnSessions(ctx context.Context) error {
 	return nil
 }
 
-// HasWebAuthnCredentials checks if any passkeys are registered
+// HasWebAuthnCredentials checks if any WebAuthn credentials exist.
 func (d *Database) HasWebAuthnCredentials(ctx context.Context) bool {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var count int
-	err := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM webauthn_credentials").Scan(&count)
+	err := d.reader.QueryRowContext(ctx, "SELECT COUNT(*) FROM webauthn_credentials").Scan(&count)
 	if err != nil {
 		logging.Debug("Failed to count WebAuthn credentials: %v", err)
 		return false
@@ -510,16 +452,13 @@ func (d *Database) HasWebAuthnCredentials(ctx context.Context) bool {
 	return count > 0
 }
 
-// CountWebAuthnCredentials returns the number of registered passkeys
+// CountWebAuthnCredentials returns the total number of WebAuthn credentials.
 func (d *Database) CountWebAuthnCredentials(ctx context.Context) int {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	var count int
-	err := d.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM webauthn_credentials").Scan(&count)
+	err := d.reader.QueryRowContext(ctx, "SELECT COUNT(*) FROM webauthn_credentials").Scan(&count)
 	if err != nil {
 		logging.Debug("Failed to count WebAuthn credentials: %v", err)
 		return 0

--- a/internal/handlers/favorites_integration_test.go
+++ b/internal/handlers/favorites_integration_test.go
@@ -62,7 +62,7 @@ func setupFavoritesIntegrationTest(t *testing.T) (h *Handlers, cleanup func()) {
 func addTestFile(t *testing.T, db *database.Database, path, name string, fileType database.FileType) {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("Failed to begin batch: %v", err)
 	}
@@ -76,13 +76,13 @@ func addTestFile(t *testing.T, db *database.Database, path, name string, fileTyp
 		ModTime:    time.Now(),
 	}
 
-	err = db.UpsertFile(ctx, tx, file)
+	err = batch.UpsertFile(ctx, file)
 	if err != nil {
-		tx.Rollback()
+		db.EndBatch(batch, err)
 		t.Fatalf("Failed to upsert test file: %v", err)
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("Failed to end batch: %v", err)
 	}
 }

--- a/internal/handlers/handlers_performance_test.go
+++ b/internal/handlers/handlers_performance_test.go
@@ -41,7 +41,7 @@ func BenchmarkGetStatsEndpoint(b *testing.B) {
 	}
 	ctx := context.Background()
 	// Create some test data
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 	for i := 0; i < 100; i++ {
 		file := database.MediaFile{
 			Name:       "test.jpg",
@@ -51,9 +51,9 @@ func BenchmarkGetStatsEndpoint(b *testing.B) {
 			Size:       1024,
 			ModTime:    time.Now(),
 		}
-		db.UpsertFile(ctx, tx, &file)
+		batch.UpsertFile(ctx, &file)
 	}
-	db.EndBatch(tx, nil)
+	db.EndBatch(batch, nil)
 
 	// Update stats
 	stats := database.IndexStats{
@@ -105,7 +105,7 @@ func BenchmarkListFilesEndpoint(b *testing.B) {
 	}
 	ctx := context.Background()
 	// Create test directory structure with many folders
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 
 	// Add 100 folders
 	for i := 0; i < 100; i++ {
@@ -117,7 +117,7 @@ func BenchmarkListFilesEndpoint(b *testing.B) {
 			Size:       0,
 			ModTime:    time.Now(),
 		}
-		db.UpsertFile(ctx, tx, &folder)
+		batch.UpsertFile(ctx, &folder)
 
 		// Add files to each folder
 		for j := 0; j < 50; j++ {
@@ -130,10 +130,10 @@ func BenchmarkListFilesEndpoint(b *testing.B) {
 				ModTime:    time.Now(),
 				MimeType:   "image/jpeg",
 			}
-			db.UpsertFile(ctx, tx, &file)
+			batch.UpsertFile(ctx, &file)
 		}
 	}
-	db.EndBatch(tx, nil)
+	db.EndBatch(batch, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -177,7 +177,7 @@ func BenchmarkGetMediaFilesEndpoint(b *testing.B) {
 
 	// Create test files with tags and favorites
 	ctx := context.Background()
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 
 	for i := 0; i < 1000; i++ {
 		file := database.MediaFile{
@@ -189,9 +189,9 @@ func BenchmarkGetMediaFilesEndpoint(b *testing.B) {
 			ModTime:    time.Now(),
 			MimeType:   "image/jpeg",
 		}
-		db.UpsertFile(ctx, tx, &file)
+		batch.UpsertFile(ctx, &file)
 	}
-	db.EndBatch(tx, nil)
+	db.EndBatch(batch, nil)
 
 	// Add some tags and favorites
 	tagName := "test"
@@ -249,7 +249,7 @@ func BenchmarkGetMediaFilesEndpoint_LargeDirectory(b *testing.B) {
 
 	// Create 14,000 files to simulate user's use case
 	ctx := context.Background()
-	tx, _ := db.BeginBatch(ctx)
+	batch, _ := db.BeginBatch(ctx)
 
 	for i := 0; i < 14000; i++ {
 		file := database.MediaFile{
@@ -261,9 +261,9 @@ func BenchmarkGetMediaFilesEndpoint_LargeDirectory(b *testing.B) {
 			ModTime:    time.Now(),
 			MimeType:   "image/jpeg",
 		}
-		db.UpsertFile(ctx, tx, &file)
+		batch.UpsertFile(ctx, &file)
 	}
-	db.EndBatch(tx, nil)
+	db.EndBatch(batch, nil)
 
 	// Add some tags and favorites (realistic ratio)
 	tagName := "vacation"

--- a/internal/handlers/media_integration_test.go
+++ b/internal/handlers/media_integration_test.go
@@ -133,15 +133,15 @@ func addExistingFileToDatabase(t *testing.T, h *Handlers, relativePath string, f
 		t.Fatalf("failed to stat file: %v", err)
 	}
 
-	// Determine parent path
 	parentPath := filepath.Dir(relativePath)
 	if parentPath == "." {
 		parentPath = ""
 	}
+
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
-	if err != nil {
-		t.Fatalf("failed to begin batch: %v", err)
+	batch, terr := h.db.BeginBatch(ctx)
+	if terr != nil {
+		t.Fatalf("failed to begin batch: %v", terr)
 	}
 
 	file := &database.MediaFile{
@@ -153,14 +153,9 @@ func addExistingFileToDatabase(t *testing.T, h *Handlers, relativePath string, f
 		ModTime:    fileInfo.ModTime(),
 	}
 
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err != nil {
-		tx.Rollback()
-		t.Fatalf("failed to upsert file: %v", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("failed to commit batch: %v", err)
+	upsertErr := batch.UpsertFile(ctx, file)
+	if endErr := h.db.EndBatch(batch, upsertErr); endErr != nil {
+		t.Fatalf("failed to end batch: %v", endErr)
 	}
 }
 
@@ -190,9 +185,9 @@ func addTestMediaFile(t *testing.T, h *Handlers, relativePath string, fileType d
 
 	ctx := context.Background()
 
-	tx, err := h.db.BeginBatch(ctx)
-	if err != nil {
-		t.Fatalf("failed to begin batch: %v", err)
+	batch, terr := h.db.BeginBatch(ctx)
+	if terr != nil {
+		t.Fatalf("failed to begin batch: %v", terr)
 	}
 
 	file := &database.MediaFile{
@@ -204,13 +199,13 @@ func addTestMediaFile(t *testing.T, h *Handlers, relativePath string, fileType d
 		ModTime:    fileInfo.ModTime(),
 	}
 
-	err = h.db.UpsertFile(ctx, tx, file)
+	err = batch.UpsertFile(ctx, file)
 	if err != nil {
-		tx.Rollback()
+		h.db.EndBatch(batch, err)
 		t.Fatalf("failed to upsert test file: %v", err)
 	}
 
-	if err := h.db.EndBatch(tx, nil); err != nil {
+	if err := h.db.EndBatch(batch, nil); err != nil {
 		t.Fatalf("failed to end batch: %v", err)
 	}
 
@@ -1191,17 +1186,17 @@ func TestListFilesFilterWithFoldersIntegration(t *testing.T) {
 		Type:       database.FileTypeFolder,
 	}
 
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin batch: %v", err)
 	}
-	if err := h.db.UpsertFile(ctx, tx, folder1); err != nil {
+	if err := batch.UpsertFile(ctx, folder1); err != nil {
 		t.Fatalf("failed to upsert folder1: %v", err)
 	}
-	if err := h.db.UpsertFile(ctx, tx, folder2); err != nil {
+	if err := batch.UpsertFile(ctx, folder2); err != nil {
 		t.Fatalf("failed to upsert folder2: %v", err)
 	}
-	if err := h.db.EndBatch(tx, nil); err != nil {
+	if err := h.db.EndBatch(batch, nil); err != nil {
 		t.Fatalf("failed to end batch: %v", err)
 	}
 
@@ -1864,7 +1859,7 @@ func TestGetThumbnailSuccessFolderIntegration(t *testing.T) {
 	}
 	ctx := context.Background()
 	// Add folder to database
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin batch: %v", err)
 	}
@@ -1877,11 +1872,11 @@ func TestGetThumbnailSuccessFolderIntegration(t *testing.T) {
 		Size:     0,
 	}
 
-	if err := h.db.UpsertFile(ctx, tx, &file); err != nil {
+	if err := batch.UpsertFile(ctx, &file); err != nil {
 		t.Fatalf("failed to insert folder: %v", err)
 	}
 
-	if err := h.db.EndBatch(tx, nil); err != nil {
+	if err := h.db.EndBatch(batch, nil); err != nil {
 		t.Fatalf("failed to end batch: %v", err)
 	}
 
@@ -3197,29 +3192,29 @@ func addTestTag(t *testing.T, h *Handlers, name string) int64 {
 	t.Helper()
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin batch for tag creation: %v", err)
 	}
 
-	result, err := tx.ExecContext(ctx,
+	result, err := batch.Tx().ExecContext(ctx,
 		"INSERT INTO tags (name, created_at) VALUES (?, strftime('%s', 'now'))", name)
 	if err != nil {
-		if rbErr := tx.Rollback(); rbErr != nil {
+		if rbErr := batch.Tx().Rollback(); rbErr != nil {
 			t.Errorf("rollback failed: %v", rbErr)
 		}
 		// Unlock the mutex that BeginBatch locked
-		h.db.EndBatch(tx, err)
+		h.db.EndBatch(batch, err)
 		t.Fatalf("failed to insert tag: %v", err)
 	}
 
 	tagID, err := result.LastInsertId()
 	if err != nil {
-		h.db.EndBatch(tx, err)
+		h.db.EndBatch(batch, err)
 		t.Fatalf("failed to get tag ID: %v", err)
 	}
 
-	if err := h.db.EndBatch(tx, nil); err != nil {
+	if err := h.db.EndBatch(batch, nil); err != nil {
 		t.Fatalf("failed to commit tag creation: %v", err)
 	}
 
@@ -3231,20 +3226,20 @@ func addTagToFile(t *testing.T, h *Handlers, filePath string, tagID int64) {
 	t.Helper()
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin batch for file tag: %v", err)
 	}
 
-	_, err = tx.ExecContext(ctx,
+	_, err = batch.Tx().ExecContext(ctx,
 		"INSERT INTO file_tags (file_path, tag_id, created_at) VALUES (?, ?, strftime('%s', 'now'))",
 		filePath, tagID)
 	if err != nil {
-		h.db.EndBatch(tx, err)
+		h.db.EndBatch(batch, err)
 		t.Fatalf("failed to add tag to file: %v", err)
 	}
 
-	if err := h.db.EndBatch(tx, nil); err != nil {
+	if err := h.db.EndBatch(batch, nil); err != nil {
 		t.Fatalf("failed to commit file tag: %v", err)
 	}
 }
@@ -3419,18 +3414,18 @@ func TestGetMediaFilesETagChangesWhenTagRemovedIntegration(t *testing.T) {
 
 	// Remove the tag
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin batch: %v", err)
 	}
-	_, err = tx.ExecContext(ctx,
+	_, err = batch.Tx().ExecContext(ctx,
 		"DELETE FROM file_tags WHERE file_path = ? AND tag_id = ?",
 		"photo.jpg", tagID)
 	if err != nil {
-		h.db.EndBatch(tx, err)
+		h.db.EndBatch(batch, err)
 		t.Fatalf("failed to remove tag: %v", err)
 	}
-	if err := h.db.EndBatch(tx, nil); err != nil {
+	if err := h.db.EndBatch(batch, nil); err != nil {
 		t.Fatalf("failed to commit tag removal: %v", err)
 	}
 

--- a/internal/handlers/playlist_integration_test.go
+++ b/internal/handlers/playlist_integration_test.go
@@ -123,7 +123,7 @@ func addPlaylistToDatabase(t *testing.T, db *database.Database, playlistPath, me
 	}
 	ctx := context.Background()
 	// Insert into database
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -136,11 +136,11 @@ func addPlaylistToDatabase(t *testing.T, db *database.Database, playlistPath, me
 		Type:    database.FileTypePlaylist,
 	}
 
-	if err := db.UpsertFile(ctx, tx, mediaFile); err != nil {
+	if err := batch.UpsertFile(ctx, mediaFile); err != nil {
 		t.Fatalf("failed to insert playlist: %v", err)
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to commit transaction: %v", err)
 	}
 }

--- a/internal/handlers/search_integration_test.go
+++ b/internal/handlers/search_integration_test.go
@@ -95,7 +95,7 @@ func addSearchTestFile(t *testing.T, db *database.Database, mediaDir, relPath st
 	}
 	ctx := context.Background()
 	// Insert into database
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -108,11 +108,11 @@ func addSearchTestFile(t *testing.T, db *database.Database, mediaDir, relPath st
 		Type:    fileType,
 	}
 
-	if err := db.UpsertFile(ctx, tx, mediaFile); err != nil {
+	if err := batch.UpsertFile(ctx, mediaFile); err != nil {
 		t.Fatalf("failed to insert file: %v", err)
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to commit transaction: %v", err)
 	}
 }

--- a/internal/handlers/tags_integration_test.go
+++ b/internal/handlers/tags_integration_test.go
@@ -100,7 +100,7 @@ func addTagTestFile(t *testing.T, db *database.Database, mediaDir, relPath strin
 	}
 	ctx := context.Background()
 	// Insert into database
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -113,11 +113,11 @@ func addTagTestFile(t *testing.T, db *database.Database, mediaDir, relPath strin
 		Type:    fileType,
 	}
 
-	if err := db.UpsertFile(ctx, tx, mediaFile); err != nil {
+	if err := batch.UpsertFile(ctx, mediaFile); err != nil {
 		t.Fatalf("failed to insert file: %v", err)
 	}
 
-	if err := db.EndBatch(tx, nil); err != nil {
+	if err = db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to commit transaction: %v", err)
 	}
 }

--- a/internal/handlers/thumbnail_coverage_test.go
+++ b/internal/handlers/thumbnail_coverage_test.go
@@ -97,7 +97,7 @@ func TestGetThumbnailFileNotOnDisk(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 	// Add file to database but don't create it on disk
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -110,8 +110,8 @@ func TestGetThumbnailFileNotOnDisk(t *testing.T) {
 		ModTime:    time.Now(),
 	}
 
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 
@@ -140,7 +140,7 @@ func TestGetThumbnailDirectoryInDatabase(t *testing.T) {
 
 	// Add to database as image (wrong type)
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -152,8 +152,8 @@ func TestGetThumbnailDirectoryInDatabase(t *testing.T) {
 		Size:       0,
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add directory to database: %v", err)
 	}
 
@@ -193,7 +193,7 @@ func TestGetThumbnailUnsupportedFileType(t *testing.T) {
 
 			// Add to database
 			ctx := context.Background()
-			tx, err := h.db.BeginBatch(ctx)
+			batch, err := h.db.BeginBatch(ctx)
 			if err != nil {
 				t.Fatalf("failed to begin transaction: %v", err)
 			}
@@ -205,8 +205,8 @@ func TestGetThumbnailUnsupportedFileType(t *testing.T) {
 				Size:       0,
 				ModTime:    time.Now(),
 			}
-			err = h.db.UpsertFile(ctx, tx, file)
-			if err = h.db.EndBatch(tx, err); err != nil {
+			err = batch.UpsertFile(ctx, file)
+			if err = h.db.EndBatch(batch, err); err != nil {
 				t.Fatalf("failed to add file to database: %v", err)
 			}
 
@@ -248,7 +248,7 @@ func TestGetThumbnailImageSuccess(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -260,8 +260,8 @@ func TestGetThumbnailImageSuccess(t *testing.T) {
 		Size:       int64(len(imageData)),
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 
@@ -312,7 +312,7 @@ func TestGetThumbnailFolderSuccess(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -324,8 +324,8 @@ func TestGetThumbnailFolderSuccess(t *testing.T) {
 		Size:       0,
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add folder to database: %v", err)
 	}
 
@@ -383,7 +383,7 @@ func TestGetThumbnailConditionalRequest(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -395,8 +395,8 @@ func TestGetThumbnailConditionalRequest(t *testing.T) {
 		Size:       int64(len(imageData)),
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 
@@ -464,7 +464,7 @@ func TestGetThumbnailConditionalRequestMismatch(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -476,8 +476,8 @@ func TestGetThumbnailConditionalRequestMismatch(t *testing.T) {
 		Size:       int64(len(imageData)),
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 
@@ -512,7 +512,7 @@ func TestGetThumbnailGenerationFailure(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -524,8 +524,8 @@ func TestGetThumbnailGenerationFailure(t *testing.T) {
 		Size:       16,
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 
@@ -553,7 +553,7 @@ func TestGetThumbnailStatError(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -565,8 +565,8 @@ func TestGetThumbnailStatError(t *testing.T) {
 		Size:       4,
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 
@@ -613,7 +613,7 @@ func TestGetThumbnailMultipleRequests(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -625,8 +625,8 @@ func TestGetThumbnailMultipleRequests(t *testing.T) {
 		Size:       int64(len(imageData)),
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 
@@ -674,7 +674,7 @@ func TestGetThumbnailVideoType(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tx, err := h.db.BeginBatch(ctx)
+	batch, err := h.db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("failed to begin transaction: %v", err)
 	}
@@ -686,8 +686,8 @@ func TestGetThumbnailVideoType(t *testing.T) {
 		Size:       18,
 		ModTime:    time.Now(),
 	}
-	err = h.db.UpsertFile(ctx, tx, file)
-	if err = h.db.EndBatch(tx, err); err != nil {
+	err = batch.UpsertFile(ctx, file)
+	if err = h.db.EndBatch(batch, err); err != nil {
 		t.Fatalf("failed to add file to database: %v", err)
 	}
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -743,18 +743,18 @@ func (idx *Indexer) processBatch(files []database.MediaFile) error {
 	ctx := context.Background()
 
 	start := time.Now()
-	tx, err := idx.db.BeginBatch(ctx)
+	batch, err := idx.db.BeginBatch(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to begin batch transaction: %w", err)
 	}
 
 	for i := range files {
-		if err := idx.db.UpsertFile(ctx, tx, &files[i]); err != nil {
+		if err := batch.UpsertFile(ctx, &files[i]); err != nil {
 			logging.Warn("Error upserting file %s: %v", files[i].Path, err)
 		}
 	}
 
-	if err := idx.db.EndBatch(tx, nil); err != nil {
+	if err := idx.db.EndBatch(batch, nil); err != nil {
 		return fmt.Errorf("failed to commit batch: %w", err)
 	}
 
@@ -765,20 +765,20 @@ func (idx *Indexer) processBatch(files []database.MediaFile) error {
 // cleanupMissingFiles removes files from the database that no longer exist on disk.
 func (idx *Indexer) cleanupMissingFiles(indexTime time.Time) error {
 	ctx := context.Background()
-	tx, err := idx.db.BeginBatch(ctx)
+	batch, err := idx.db.BeginBatch(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to begin cleanup transaction: %w", err)
 	}
 
-	deleted, err := idx.db.DeleteMissingFiles(ctx, tx, indexTime)
+	deleted, err := batch.DeleteMissingFiles(ctx, indexTime)
 	if err != nil {
-		if endErr := idx.db.EndBatch(tx, err); endErr != nil {
+		if endErr := idx.db.EndBatch(batch, err); endErr != nil {
 			logging.Error("failed to end batch after cleanup error: %v", endErr)
 		}
 		return err
 	}
 
-	if err := idx.db.EndBatch(tx, nil); err != nil {
+	if err := idx.db.EndBatch(batch, nil); err != nil {
 		return fmt.Errorf("failed to commit cleanup: %w", err)
 	}
 

--- a/internal/media/thumbnail_integration_test.go
+++ b/internal/media/thumbnail_integration_test.go
@@ -2357,12 +2357,12 @@ func TestProcessFilesForGenerationIncrementalIntegration(t *testing.T) {
 // to insert a single file using the real database API.
 func upsertTestFile(ctx context.Context, t *testing.T, db *database.Database, file database.MediaFile) {
 	t.Helper()
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
-	upsertErr := db.UpsertFile(ctx, tx, &file)
-	if err := db.EndBatch(tx, upsertErr); err != nil {
+	upsertErr := batch.UpsertFile(ctx, &file)
+	if err := db.EndBatch(batch, upsertErr); err != nil {
 		t.Fatalf("UpsertFile failed: %v", err)
 	}
 }
@@ -2385,20 +2385,20 @@ func deleteTestFile(ctx context.Context, t *testing.T, db *database.Database, ke
 	// original inserts, causing DeleteMissingFiles to find nothing to delete.
 	cutoff := time.Now()
 
-	tx, err := db.BeginBatch(ctx)
+	batch, err := db.BeginBatch(ctx)
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
 
 	for i := range keepFiles {
-		if upsertErr := db.UpsertFile(ctx, tx, &keepFiles[i]); upsertErr != nil {
-			_ = db.EndBatch(tx, upsertErr)
+		if upsertErr := batch.UpsertFile(ctx, &keepFiles[i]); upsertErr != nil {
+			_ = db.EndBatch(batch, upsertErr)
 			t.Fatalf("UpsertFile failed: %v", upsertErr)
 		}
 	}
 
-	deleted, deleteErr := db.DeleteMissingFiles(ctx, tx, cutoff)
-	if err := db.EndBatch(tx, deleteErr); err != nil {
+	deleted, deleteErr := batch.DeleteMissingFiles(ctx, cutoff)
+	if err := db.EndBatch(batch, deleteErr); err != nil {
 		t.Fatalf("EndBatch failed: %v", err)
 	}
 	t.Logf("DeleteMissingFiles removed %d rows", deleted)


### PR DESCRIPTION
Fixes #338

## Description

Database layer refactored for significantly improved performance and concurrency ([#338](https://github.com/djryanj/media-viewer/issues/338)
    - Removed application-level sync.RWMutex from all database operations. SQLite WAL mode with busy_timeout now handles all read/write concurrency internally, eliminating unnecessary Go-level serialization that was blocking concurrent readers during writes.
    - WAL mode and all SQLite PRAGMAs (synchronous, cache_size, temp_store, busy_timeout, mmap_size) moved from the connection string to a ConnectHook, ensuring consistent per-connection configuration across the pool.
    - Introduced separate reader and writer connection pools. The writer pool is limited to a single connection (eliminating SQLITE_BUSY between writers entirely), while the reader pool allows up to 16 concurrent read connections under WAL mode.
    - Introduced BatchInserter type for batch indexing operations. The upsert and delete prepared statements are now created once per batch and reused across all files, eliminating repeated query parsing during indexing.
    - BeginBatch now returns a \*BatchInserter (breaking API change). UpsertFile and DeleteMissingFiles are now methods on BatchInserter rather than Database.
    - Fixed N+1 query pattern in GetFilesByTag — per-row tag and favorite lookups replaced with scalar subqueries in the main SQL query.
    - Benchmark results show 2× faster writes (UpsertFile), 11% faster directory listings, and up to 16% faster large read operations with many tags.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [X] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [X] Database
- [ ] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have run `make pr-check` and all checks passed
    - Lint fixes: ✓
    - Tests: ✓
    - Race detector: ✓

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
