### PR TITLE
perf: Performance slowdown in the middle of large galleries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [0.15.1] - Unreleased
+
+### Fixed
+
+- perf(frontend): `lucide.createIcons()` was called three times on every lightbox navigation (pin button, tag button, and loop/autoplay toggle) because each `updatePinButton`, `updateTagButton`, and `updateLoopButton` call replaced `innerHTML` and re-rendered icons from scratch. On every next/prev click this triggered a full DOM mutation, causing the Lucide library and browser extensions to re-scan the subtree. Fixed by adding `_initStaticIcons()`, called once at lightbox startup, which writes the icon `<i>` elements and calls `lucide.createIcons({ nodes })` a single time. All update functions now only toggle CSS classes and the button `title` — no DOM mutation occurs during navigation. [#114](https://github.com/djryanj/media-viewer/issues/114)
+- perf(frontend): `getTagsFromGallery` performed an O(n) `document.querySelector` scan on every tag lookup. The function now checks `InfiniteScroll._galleryItemsByPath` (a `Map` populated by `renderItems`) first, falling back to the DOM scan only when InfiniteScroll is unavailable or the path is absent from the map. [#114](https://github.com/djryanj/media-viewer/issues/114)
+- perf(frontend): `_getGridGeometry` forced a synchronous layout reflow on every call by reading `getComputedStyle` and `offsetWidth`. The result is now cached in `_cachedGridGeometry` and reused until explicitly invalidated. The cache is cleared by `_positionScrubber` (called on resize), by a full re-render in `renderItems`, and by `resetState`. [#114](https://github.com/djryanj/media-viewer/issues/114)
+
 ## [0.15.0] - 03-01-2026
 
 ### Changed

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1975,6 +1975,37 @@ select:focus {
     display: none;
 }
 
+/*
+ * Autoplay / loop buttons contain both icon states pre-rendered.
+ * CSS (not JS) decides which SVG is visible based on the .enabled class,
+ * avoiding innerHTML mutations and lucide.createIcons() on every navigation.
+ *
+ * Default (off): show the "off" icon; enabled: swap to the "on" icon.
+ */
+.lightbox-autoplay [data-lucide='play-circle'] {
+    display: none;
+}
+
+.lightbox-autoplay.enabled [data-lucide='play-circle'] {
+    display: inline;
+}
+
+.lightbox-autoplay.enabled [data-lucide='pause-circle'] {
+    display: none;
+}
+
+.lightbox-loop-toggle [data-lucide='repeat'] {
+    display: none;
+}
+
+.lightbox-loop-toggle.enabled [data-lucide='repeat'] {
+    display: inline;
+}
+
+.lightbox-loop-toggle.enabled [data-lucide='repeat-1'] {
+    display: none;
+}
+
 /* ===========================================
    LIGHTBOX TAG SUMMARY (in info bar)
    =========================================== */

--- a/static/js/infinite-scroll.js
+++ b/static/js/infinite-scroll.js
@@ -54,6 +54,14 @@ const InfiniteScroll = {
     _restorePopoverTimer: null, // auto-dismiss timer for restore popover
     _saveScrollTimer: null, // debounce timer for persistent position save
 
+    // Cached grid geometry — invalidated on resize and renderItems so we
+    // don't force synchronous layout on every updateVirtualSpacer call.
+    _cachedGridGeometry: null,
+
+    // Path → DOM element map for O(1) gallery item lookups (used by Lightbox
+    // to read tag data without a full DOM querySelector scan).
+    _galleryItemsByPath: new Map(),
+
     // ── Elements ─────────────────────────────────────────────────────────────
     elements: {},
 
@@ -128,6 +136,8 @@ const InfiniteScroll = {
      * sticky chrome.  Must be called AFTER the elements exist in the DOM.
      */
     _positionScrubber() {
+        // Grid column widths may have changed on resize, so invalidate the cache.
+        this._cachedGridGeometry = null;
         const scrubber = this.elements.scrubber;
         if (!scrubber) return;
         const header = document.querySelector('.header');
@@ -299,6 +309,8 @@ const InfiniteScroll = {
         this._catchUpTarget = 0;
         this._isScrubbing = false;
         this._scrubFraction = 0;
+        this._cachedGridGeometry = null;
+        this._galleryItemsByPath.clear();
         clearTimeout(this._catchUpTimer);
         clearTimeout(this._saveScrollTimer);
         document.documentElement.classList.remove('catchup-active', 'custom-scrubber-active');
@@ -330,6 +342,7 @@ const InfiniteScroll = {
     // Grid geometry (exact values from live browser layout)
     // ─────────────────────────────────────────────────────────────────────────
     _getGridGeometry() {
+        if (this._cachedGridGeometry) return this._cachedGridGeometry;
         const gallery = this.elements.gallery;
         if (!gallery) return { cols: 3, gap: 2, itemSize: 120, rowHeight: 122 };
         const cs = getComputedStyle(gallery);
@@ -339,7 +352,8 @@ const InfiniteScroll = {
         const itemSize = item
             ? item.offsetWidth
             : Math.floor((gallery.offsetWidth - gap * (cols - 1)) / cols);
-        return { cols, gap, itemSize, rowHeight: itemSize + gap };
+        this._cachedGridGeometry = { cols, gap, itemSize, rowHeight: itemSize + gap };
+        return this._cachedGridGeometry;
     },
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -727,7 +741,13 @@ const InfiniteScroll = {
     // ─────────────────────────────────────────────────────────────────────────
     renderItems(items, append = false) {
         const gallery = this.elements.gallery;
-        if (!append) gallery.innerHTML = '';
+        if (!append) {
+            gallery.innerHTML = '';
+            // New gallery contents invalidate both the geometry cache and the
+            // path-to-element lookup map.
+            this._cachedGridGeometry = null;
+            this._galleryItemsByPath.clear();
+        }
 
         if (!items || items.length === 0) {
             if (!append) {
@@ -743,6 +763,7 @@ const InfiniteScroll = {
 
         const fragment = document.createDocumentFragment();
         const startIndex = append ? this.state.loadedItems.length - items.length : 0;
+        const createdElements = [];
         items.forEach((item, i) => {
             const element = Gallery.createGalleryItem(item);
             element.dataset.index = startIndex + i;
@@ -750,8 +771,15 @@ const InfiniteScroll = {
                 if (ItemSelection.selectedPaths.has(item.path)) element.classList.add('selected');
             }
             fragment.appendChild(element);
+            createdElements.push({ path: item.path, element });
         });
         gallery.appendChild(fragment);
+
+        // Populate the path-to-element map for fast tag lookups.
+        for (const { path, element } of createdElements) {
+            this._galleryItemsByPath.set(path, element);
+        }
+
         lucide.createIcons();
 
         if (typeof ItemSelection !== 'undefined' && ItemSelection.isActive) {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -62,6 +62,7 @@ const Lightbox = {
 
     init() {
         this.cacheElements();
+        this._initStaticIcons();
         this.videoControlsHeight = 0;
         this.createHotZones();
         this.createLoadingIndicator();
@@ -103,12 +104,34 @@ const Lightbox = {
         };
     },
 
+    /**
+     * Render static icons (pin, tag) once at init time so that
+     * updatePinButton / updateTagButton never need to touch innerHTML or
+     * call lucide.createIcons() on every navigation — eliminating the DOM
+     * mutation cascade that triggers browser extensions on each next/open.
+     */
+    _initStaticIcons() {
+        if (this.elements.pinBtn) {
+            this.elements.pinBtn.innerHTML = '<i data-lucide="star"></i>';
+        }
+        if (this.elements.tagBtn) {
+            this.elements.tagBtn.innerHTML = '<i data-lucide="tag"></i>';
+        }
+        const nodes = [this.elements.pinBtn, this.elements.tagBtn].filter(Boolean);
+        if (nodes.length) lucide.createIcons({ nodes });
+    },
+
     createAutoplayToggle() {
         const toggle = document.createElement('button');
         toggle.className = 'lightbox-autoplay hidden';
         toggle.id = 'lightbox-autoplay';
         toggle.title = 'Toggle video autoplay (A)';
-        this.updateAutoplayButton(toggle);
+        // Pre-render both icon states once; CSS + .enabled class selects the
+        // visible icon so updateAutoplayButton() never touches the DOM again.
+        toggle.innerHTML = [
+            '<i data-lucide="play-circle" class="icon-autoplay-on"></i>',
+            '<i data-lucide="pause-circle" class="icon-autoplay-off"></i>',
+        ].join('');
 
         toggle.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -123,18 +146,17 @@ const Lightbox = {
         }
 
         this.elements.autoplayBtn = toggle;
-        lucide.createIcons();
+        lucide.createIcons({ nodes: [toggle] });
+        this.updateAutoplayButton();
     },
 
     updateAutoplayButton(btn = this.elements.autoplayBtn) {
         if (!btn) return;
         const isEnabled = Preferences.isVideoAutoplayEnabled();
         btn.classList.toggle('enabled', isEnabled);
-        btn.innerHTML = isEnabled
-            ? '<i data-lucide="play-circle"></i>'
-            : '<i data-lucide="pause-circle"></i>';
         btn.title = isEnabled ? 'Autoplay ON (A)' : 'Autoplay OFF (A)';
-        lucide.createIcons({ nodes: [btn] });
+        // Icon visibility is controlled by CSS (.enabled toggles play-circle vs pause-circle).
+        // No innerHTML mutation or lucide.createIcons() call needed.
     },
 
     toggleAutoplay() {
@@ -150,7 +172,12 @@ const Lightbox = {
         toggle.className = 'lightbox-loop-toggle hidden';
         toggle.id = 'lightbox-loop-toggle';
         toggle.title = 'Toggle loop (L)';
-        this.updateLoopButton(toggle);
+        // Pre-render both icon states once; CSS + .enabled class selects the
+        // visible icon so updateLoopButton() never touches the DOM again.
+        toggle.innerHTML = [
+            '<i data-lucide="repeat" class="icon-loop-on"></i>',
+            '<i data-lucide="repeat-1" class="icon-loop-off"></i>',
+        ].join('');
 
         toggle.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -165,18 +192,17 @@ const Lightbox = {
         }
 
         this.elements.loopBtn = toggle;
-        lucide.createIcons();
+        lucide.createIcons({ nodes: [toggle] });
+        this.updateLoopButton();
     },
 
     updateLoopButton(btn = this.elements.loopBtn) {
         if (!btn) return;
         const isEnabled = Preferences.isMediaLoopEnabled();
         btn.classList.toggle('enabled', isEnabled);
-        btn.innerHTML = isEnabled
-            ? '<i data-lucide="repeat"></i>'
-            : '<i data-lucide="repeat-1"></i>';
         btn.title = isEnabled ? 'Loop ON (L)' : 'Loop OFF (L)';
-        lucide.createIcons({ nodes: [btn] });
+        // Icon visibility is controlled by CSS (.enabled toggles repeat vs repeat-1).
+        // No innerHTML mutation or lucide.createIcons() call needed.
     },
 
     toggleLoop() {
@@ -1762,9 +1788,13 @@ const Lightbox = {
     },
 
     getTagsFromGallery(path) {
-        const galleryItem = document.querySelector(
-            `.gallery-item[data-path="${CSS.escape(path)}"]`
-        );
+        // Use the O(1) path-to-element map maintained by InfiniteScroll when
+        // available, falling back to a full DOM scan for non-infinite-scroll
+        // contexts (search, playlist, etc.).
+        const galleryItem =
+            (typeof InfiniteScroll !== 'undefined' &&
+                InfiniteScroll._galleryItemsByPath?.get(path)) ||
+            document.querySelector(`.gallery-item[data-path="${CSS.escape(path)}"]`);
         if (!galleryItem) return null;
         const tagsContainer = galleryItem.querySelector('.gallery-item-tags');
         if (!tagsContainer && !galleryItem.querySelector('.tag-button.has-tags')) return [];
@@ -2195,11 +2225,11 @@ const Lightbox = {
         const isPinned =
             file.isFavorite || (typeof Favorites !== 'undefined' && Favorites.isPinned(file.path));
         this.elements.pinBtn.classList.toggle('pinned', isPinned);
-        this.elements.pinBtn.innerHTML = '<i data-lucide="star"></i>';
         this.elements.pinBtn.title = isPinned
             ? 'Remove from favorites (F)'
             : 'Add to favorites (F)';
-        lucide.createIcons({ nodes: [this.elements.pinBtn] });
+        // Icon (star SVG) was rendered once in _initStaticIcons().
+        // Only the CSS class and title change — no DOM mutation, no lucide call.
     },
 
     togglePin() {
@@ -2244,9 +2274,9 @@ const Lightbox = {
         if (!this.elements.tagBtn) return;
         const hasTags = file.tags && file.tags.length > 0;
         this.elements.tagBtn.classList.toggle('has-tags', hasTags);
-        this.elements.tagBtn.innerHTML = '<i data-lucide="tag"></i>';
         this.elements.tagBtn.title = 'Manage tags (T)';
-        lucide.createIcons({ nodes: [this.elements.tagBtn] });
+        // Icon (tag SVG) was rendered once in _initStaticIcons().
+        // Only the CSS class changes — no DOM mutation, no lucide call.
     },
 
     downloadCurrent() {

--- a/static/tests/unit/infinite-scroll.test.js
+++ b/static/tests/unit/infinite-scroll.test.js
@@ -178,6 +178,31 @@ describe('InfiniteScroll Module', () => {
 
             expect(clearSpy).toHaveBeenCalledWith(42);
         });
+
+        test('sets _cachedGridGeometry to null', () => {
+            InfiniteScroll._cachedGridGeometry = { cols: 4, gap: 8, itemSize: 200, rowHeight: 208 };
+            InfiniteScroll.elements = {
+                skeletonContainer: { classList: { add: vi.fn() } },
+                loadMoreBtn: { classList: { add: vi.fn() } },
+            };
+
+            InfiniteScroll.resetState();
+
+            expect(InfiniteScroll._cachedGridGeometry).toBeNull();
+        });
+
+        test('clears _galleryItemsByPath map', () => {
+            InfiniteScroll._galleryItemsByPath.set('/img1.jpg', document.createElement('div'));
+            InfiniteScroll._galleryItemsByPath.set('/img2.jpg', document.createElement('div'));
+            InfiniteScroll.elements = {
+                skeletonContainer: { classList: { add: vi.fn() } },
+                loadMoreBtn: { classList: { add: vi.fn() } },
+            };
+
+            InfiniteScroll.resetState();
+
+            expect(InfiniteScroll._galleryItemsByPath.size).toBe(0);
+        });
     });
 
     describe('Cache operations - saveToCache()', () => {
@@ -1203,6 +1228,148 @@ describe('InfiniteScroll Module', () => {
             sentinel.getBoundingClientRect = () => ({ top: 400, bottom: 420 });
             InfiniteScroll.checkAndFillViewport();
             expect(spy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // =========================================
+    // _galleryItemsByPath map
+    // =========================================
+
+    describe('_galleryItemsByPath — path-to-element map', () => {
+        const items = [
+            { path: '/img1.jpg', name: 'img1.jpg', type: 'image' },
+            { path: '/img2.jpg', name: 'img2.jpg', type: 'image' },
+        ];
+
+        beforeEach(() => {
+            InfiniteScroll.state.loadedItems = [];
+            InfiniteScroll.elements = {
+                ...InfiniteScroll.elements,
+                gallery: document.getElementById('gallery'),
+            };
+        });
+
+        test('renderItems() populates the map with path→element entries', () => {
+            InfiniteScroll.renderItems(items);
+
+            expect(InfiniteScroll._galleryItemsByPath.size).toBe(2);
+            expect(InfiniteScroll._galleryItemsByPath.has('/img1.jpg')).toBe(true);
+            expect(InfiniteScroll._galleryItemsByPath.has('/img2.jpg')).toBe(true);
+        });
+
+        test('map entry points to the correct DOM element for the given path', () => {
+            InfiniteScroll.renderItems(items);
+
+            const el = InfiniteScroll._galleryItemsByPath.get('/img1.jpg');
+
+            expect(el).toBeTruthy();
+            expect(el.dataset.path).toBe('/img1.jpg');
+        });
+
+        test('renderItems() with append=false clears stale entries before populating', () => {
+            InfiniteScroll._galleryItemsByPath.set('/old.jpg', document.createElement('div'));
+
+            InfiniteScroll.renderItems(items, false);
+
+            expect(InfiniteScroll._galleryItemsByPath.has('/old.jpg')).toBe(false);
+            expect(InfiniteScroll._galleryItemsByPath.size).toBe(2);
+        });
+
+        test('renderItems() with append=true adds to existing map entries', () => {
+            InfiniteScroll.renderItems(items, false);
+            InfiniteScroll.state.loadedItems = [...items];
+
+            const extra = [{ path: '/img3.jpg', name: 'img3.jpg', type: 'image' }];
+            InfiniteScroll.renderItems(extra, true);
+
+            expect(InfiniteScroll._galleryItemsByPath.size).toBe(3);
+            expect(InfiniteScroll._galleryItemsByPath.has('/img3.jpg')).toBe(true);
+        });
+
+        test('renderItems() with append=true preserves existing map entries', () => {
+            InfiniteScroll.renderItems(items, false);
+            InfiniteScroll.state.loadedItems = [...items];
+            const extra = [{ path: '/img3.jpg', name: 'img3.jpg', type: 'image' }];
+
+            InfiniteScroll.renderItems(extra, true);
+
+            expect(InfiniteScroll._galleryItemsByPath.has('/img1.jpg')).toBe(true);
+            expect(InfiniteScroll._galleryItemsByPath.has('/img2.jpg')).toBe(true);
+        });
+    });
+
+    // =========================================
+    // _cachedGridGeometry cache
+    // =========================================
+
+    describe('_cachedGridGeometry — grid geometry cache', () => {
+        beforeEach(() => {
+            InfiniteScroll.elements = {
+                ...InfiniteScroll.elements,
+                gallery: document.getElementById('gallery'),
+                scrubber: null,
+            };
+            InfiniteScroll._cachedGridGeometry = null;
+        });
+
+        test('renderItems() with append=false sets _cachedGridGeometry to null', () => {
+            InfiniteScroll._cachedGridGeometry = { cols: 4, gap: 8, itemSize: 200, rowHeight: 208 };
+            InfiniteScroll.state.loadedItems = [];
+
+            InfiniteScroll.renderItems([], false);
+
+            expect(InfiniteScroll._cachedGridGeometry).toBeNull();
+        });
+
+        test('renderItems() with append=true does not clear _cachedGridGeometry', () => {
+            const cached = { cols: 4, gap: 8, itemSize: 200, rowHeight: 208 };
+            InfiniteScroll._cachedGridGeometry = cached;
+            InfiniteScroll.state.loadedItems = [];
+
+            InfiniteScroll.renderItems([], true);
+
+            expect(InfiniteScroll._cachedGridGeometry).toBe(cached);
+        });
+
+        test('_positionScrubber() sets _cachedGridGeometry to null', () => {
+            InfiniteScroll._cachedGridGeometry = { cols: 4, gap: 8, itemSize: 200, rowHeight: 208 };
+
+            InfiniteScroll._positionScrubber();
+
+            expect(InfiniteScroll._cachedGridGeometry).toBeNull();
+        });
+
+        test('_getGridGeometry() returns same cached object on second call', () => {
+            const result1 = InfiniteScroll._getGridGeometry();
+
+            // Make gallery appear to have a different width — a fresh compute would differ
+            Object.defineProperty(InfiniteScroll.elements.gallery, 'offsetWidth', {
+                value: 9999,
+                configurable: true,
+            });
+            const result2 = InfiniteScroll._getGridGeometry();
+
+            expect(result2).toBe(result1);
+        });
+
+        test('_getGridGeometry() computes a new value after cache is cleared', () => {
+            const result1 = InfiniteScroll._getGridGeometry();
+            InfiniteScroll._cachedGridGeometry = null;
+
+            const result2 = InfiniteScroll._getGridGeometry();
+
+            // Both are valid geometry objects but are distinct references
+            expect(result2).not.toBe(result1);
+            expect(result2).toHaveProperty('cols');
+            expect(result2).toHaveProperty('rowHeight');
+        });
+
+        test('_getGridGeometry() returns a default geometry when gallery element is null', () => {
+            InfiniteScroll.elements.gallery = null;
+
+            const geo = InfiniteScroll._getGridGeometry();
+
+            expect(geo).toEqual({ cols: 3, gap: 2, itemSize: 120, rowHeight: 122 });
         });
     });
 });

--- a/static/tests/unit/lightbox.test.js
+++ b/static/tests/unit/lightbox.test.js
@@ -1417,6 +1417,76 @@ describe('Lightbox Module', () => {
 
             expect(tags).toBeNull();
         });
+
+        test('getTagsFromGallery uses InfiniteScroll._galleryItemsByPath map when available', () => {
+            const el = document.createElement('div');
+            el.className = 'gallery-item';
+            el.dataset.path = '/mapped.jpg';
+            el.innerHTML = `<div class="gallery-item-tags" data-all-tags='["map-tag"]'></div>`;
+
+            globalThis.InfiniteScroll = {
+                _galleryItemsByPath: new Map([['/mapped.jpg', el]]),
+            };
+
+            const tags = Lightbox.getTagsFromGallery('/mapped.jpg');
+
+            expect(tags).toEqual(['map-tag']);
+
+            delete globalThis.InfiniteScroll;
+        });
+
+        test('getTagsFromGallery falls back to DOM scan when InfiniteScroll is undefined', () => {
+            delete globalThis.InfiniteScroll;
+            document.body.innerHTML += `
+                <div class="gallery-item" data-path="/dom-only.jpg">
+                    <div class="gallery-item-tags" data-all-tags='["dom-tag"]'></div>
+                </div>
+            `;
+
+            const tags = Lightbox.getTagsFromGallery('/dom-only.jpg');
+
+            expect(tags).toEqual(['dom-tag']);
+        });
+
+        test('getTagsFromGallery falls back to DOM scan when path is not in the map', () => {
+            globalThis.InfiniteScroll = {
+                _galleryItemsByPath: new Map(),
+            };
+            document.body.innerHTML += `
+                <div class="gallery-item" data-path="/fallback.jpg">
+                    <div class="gallery-item-tags" data-all-tags='["fallback-tag"]'></div>
+                </div>
+            `;
+
+            const tags = Lightbox.getTagsFromGallery('/fallback.jpg');
+
+            expect(tags).toEqual(['fallback-tag']);
+
+            delete globalThis.InfiniteScroll;
+        });
+
+        test('getTagsFromGallery map lookup takes precedence over DOM element with same path', () => {
+            const mapEl = document.createElement('div');
+            mapEl.className = 'gallery-item';
+            mapEl.dataset.path = '/shared.jpg';
+            mapEl.innerHTML = `<div class="gallery-item-tags" data-all-tags='["from-map"]'></div>`;
+
+            document.body.innerHTML += `
+                <div class="gallery-item" data-path="/shared.jpg">
+                    <div class="gallery-item-tags" data-all-tags='["from-dom"]'></div>
+                </div>
+            `;
+
+            globalThis.InfiniteScroll = {
+                _galleryItemsByPath: new Map([['/shared.jpg', mapEl]]),
+            };
+
+            const tags = Lightbox.getTagsFromGallery('/shared.jpg');
+
+            expect(tags).toEqual(['from-map']);
+
+            delete globalThis.InfiniteScroll;
+        });
     });
 
     // =========================================
@@ -1653,6 +1723,39 @@ describe('Lightbox Module', () => {
             expect(button.title).toContain('ON');
         });
 
+        test('updateAutoplayButton adds .enabled class when autoplay is on', () => {
+            const button = document.createElement('button');
+            Preferences.isVideoAutoplayEnabled = vi.fn(() => true);
+
+            Lightbox.updateAutoplayButton(button);
+
+            expect(button.classList.contains('enabled')).toBe(true);
+        });
+
+        test('updateAutoplayButton removes .enabled class when autoplay is off', () => {
+            const button = document.createElement('button');
+            button.classList.add('enabled');
+            Preferences.isVideoAutoplayEnabled = vi.fn(() => false);
+
+            Lightbox.updateAutoplayButton(button);
+
+            expect(button.classList.contains('enabled')).toBe(false);
+        });
+
+        test('updateAutoplayButton does not call lucide.createIcons()', () => {
+            const button = document.createElement('button');
+            Preferences.isVideoAutoplayEnabled = vi.fn(() => true);
+            lucide.createIcons.mockClear();
+
+            Lightbox.updateAutoplayButton(button);
+
+            expect(lucide.createIcons).not.toHaveBeenCalled();
+        });
+
+        test('updateAutoplayButton returns early and does not throw when btn is null', () => {
+            expect(() => Lightbox.updateAutoplayButton(null)).not.toThrow();
+        });
+
         test('updateLoopButton shows correct state', () => {
             const button = document.createElement('button');
             Preferences.isMediaLoopEnabled = vi.fn(() => false);
@@ -1660,6 +1763,39 @@ describe('Lightbox Module', () => {
             Lightbox.updateLoopButton(button);
 
             expect(button.title).toContain('OFF');
+        });
+
+        test('updateLoopButton adds .enabled class when loop is on', () => {
+            const button = document.createElement('button');
+            Preferences.isMediaLoopEnabled = vi.fn(() => true);
+
+            Lightbox.updateLoopButton(button);
+
+            expect(button.classList.contains('enabled')).toBe(true);
+        });
+
+        test('updateLoopButton removes .enabled class when loop is off', () => {
+            const button = document.createElement('button');
+            button.classList.add('enabled');
+            Preferences.isMediaLoopEnabled = vi.fn(() => false);
+
+            Lightbox.updateLoopButton(button);
+
+            expect(button.classList.contains('enabled')).toBe(false);
+        });
+
+        test('updateLoopButton does not call lucide.createIcons()', () => {
+            const button = document.createElement('button');
+            Preferences.isMediaLoopEnabled = vi.fn(() => true);
+            lucide.createIcons.mockClear();
+
+            Lightbox.updateLoopButton(button);
+
+            expect(lucide.createIcons).not.toHaveBeenCalled();
+        });
+
+        test('updateLoopButton returns early and does not throw when btn is null', () => {
+            expect(() => Lightbox.updateLoopButton(null)).not.toThrow();
         });
     });
 
@@ -1801,6 +1937,207 @@ describe('Lightbox Module', () => {
             Lightbox.stopAnimationLoopDetection();
 
             expect(Lightbox.lastImageData).toBeNull();
+        });
+    });
+
+    // =========================================
+    // _initStaticIcons
+    // =========================================
+
+    describe('_initStaticIcons()', () => {
+        beforeEach(() => {
+            // The outer beforeEach only calls cacheElements(), not init().
+            // Call _initStaticIcons() explicitly so each test starts with
+            // icons already rendered and lucide mock calls recorded cleanly.
+            lucide.createIcons.mockClear();
+            Lightbox._initStaticIcons();
+        });
+
+        test('renders star icon markup into pinBtn', () => {
+            expect(Lightbox.elements.pinBtn.innerHTML).toContain('data-lucide="star"');
+        });
+
+        test('renders tag icon markup into tagBtn', () => {
+            expect(Lightbox.elements.tagBtn.innerHTML).toContain('data-lucide="tag"');
+        });
+
+        test('calls lucide.createIcons() with pinBtn and tagBtn as nodes during init', () => {
+            const calls = lucide.createIcons.mock.calls;
+            const iconInitCall = calls.find(
+                (c) => c[0]?.nodes && c[0].nodes.includes(Lightbox.elements.pinBtn)
+            );
+            expect(iconInitCall).toBeTruthy();
+        });
+
+        test('does not throw when pinBtn is absent', () => {
+            Lightbox.elements.pinBtn = null;
+            expect(() => Lightbox._initStaticIcons()).not.toThrow();
+        });
+
+        test('does not throw when tagBtn is absent', () => {
+            Lightbox.elements.tagBtn = null;
+            expect(() => Lightbox._initStaticIcons()).not.toThrow();
+        });
+
+        test('does not call lucide.createIcons() when both buttons are absent', () => {
+            Lightbox.elements.pinBtn = null;
+            Lightbox.elements.tagBtn = null;
+            lucide.createIcons.mockClear();
+
+            Lightbox._initStaticIcons();
+
+            expect(lucide.createIcons).not.toHaveBeenCalled();
+        });
+    });
+
+    // =========================================
+    // updatePinButton
+    // =========================================
+
+    describe('updatePinButton()', () => {
+        let file;
+
+        beforeEach(() => {
+            file = { path: '/test.jpg', name: 'test.jpg', isFavorite: false };
+            globalThis.Favorites = {
+                isPinned: vi.fn(() => false),
+                toggleFavorite: vi.fn(() => Promise.resolve(false)),
+            };
+        });
+
+        afterEach(() => {
+            delete globalThis.Favorites;
+        });
+
+        test('adds .pinned class when file.isFavorite is true', () => {
+            file.isFavorite = true;
+
+            Lightbox.updatePinButton(file);
+
+            expect(Lightbox.elements.pinBtn.classList.contains('pinned')).toBe(true);
+        });
+
+        test('removes .pinned class when file is not a favorite', () => {
+            Lightbox.elements.pinBtn.classList.add('pinned');
+            file.isFavorite = false;
+
+            Lightbox.updatePinButton(file);
+
+            expect(Lightbox.elements.pinBtn.classList.contains('pinned')).toBe(false);
+        });
+
+        test('adds .pinned class when Favorites.isPinned() returns true', () => {
+            Favorites.isPinned = vi.fn(() => true);
+
+            Lightbox.updatePinButton(file);
+
+            expect(Lightbox.elements.pinBtn.classList.contains('pinned')).toBe(true);
+        });
+
+        test('sets title to remove-from-favorites message when pinned', () => {
+            file.isFavorite = true;
+
+            Lightbox.updatePinButton(file);
+
+            expect(Lightbox.elements.pinBtn.title).toContain('Remove from favorites');
+        });
+
+        test('sets title to add-to-favorites message when not pinned', () => {
+            file.isFavorite = false;
+
+            Lightbox.updatePinButton(file);
+
+            expect(Lightbox.elements.pinBtn.title).toContain('Add to favorites');
+        });
+
+        test('does not call lucide.createIcons()', () => {
+            lucide.createIcons.mockClear();
+
+            Lightbox.updatePinButton(file);
+
+            expect(lucide.createIcons).not.toHaveBeenCalled();
+        });
+
+        test('does not mutate pinBtn innerHTML', () => {
+            const originalHTML = Lightbox.elements.pinBtn.innerHTML;
+
+            Lightbox.updatePinButton(file);
+
+            expect(Lightbox.elements.pinBtn.innerHTML).toBe(originalHTML);
+        });
+
+        test('works gracefully when Favorites global is undefined', () => {
+            delete globalThis.Favorites;
+            file.isFavorite = false;
+
+            expect(() => Lightbox.updatePinButton(file)).not.toThrow();
+            expect(Lightbox.elements.pinBtn.classList.contains('pinned')).toBe(false);
+        });
+    });
+
+    // =========================================
+    // updateTagButton
+    // =========================================
+
+    describe('updateTagButton()', () => {
+        let file;
+
+        beforeEach(() => {
+            file = { path: '/test.jpg', name: 'test.jpg', tags: [] };
+        });
+
+        test('adds .has-tags class when file has tags', () => {
+            file.tags = ['nature', 'beach'];
+
+            Lightbox.updateTagButton(file);
+
+            expect(Lightbox.elements.tagBtn.classList.contains('has-tags')).toBe(true);
+        });
+
+        test('removes .has-tags class when file has no tags', () => {
+            Lightbox.elements.tagBtn.classList.add('has-tags');
+            file.tags = [];
+
+            Lightbox.updateTagButton(file);
+
+            expect(Lightbox.elements.tagBtn.classList.contains('has-tags')).toBe(false);
+        });
+
+        test('removes .has-tags class when file.tags is undefined', () => {
+            Lightbox.elements.tagBtn.classList.add('has-tags');
+            file.tags = undefined;
+
+            Lightbox.updateTagButton(file);
+
+            expect(Lightbox.elements.tagBtn.classList.contains('has-tags')).toBe(false);
+        });
+
+        test('sets title to manage-tags message', () => {
+            Lightbox.updateTagButton(file);
+
+            expect(Lightbox.elements.tagBtn.title).toContain('Manage tags');
+        });
+
+        test('does not call lucide.createIcons()', () => {
+            lucide.createIcons.mockClear();
+
+            Lightbox.updateTagButton(file);
+
+            expect(lucide.createIcons).not.toHaveBeenCalled();
+        });
+
+        test('does not mutate tagBtn innerHTML', () => {
+            const originalHTML = Lightbox.elements.tagBtn.innerHTML;
+
+            Lightbox.updateTagButton(file);
+
+            expect(Lightbox.elements.tagBtn.innerHTML).toBe(originalHTML);
+        });
+
+        test('returns early without throwing when tagBtn is null', () => {
+            Lightbox.elements.tagBtn = null;
+
+            expect(() => Lightbox.updateTagButton(file)).not.toThrow();
         });
     });
 });


### PR DESCRIPTION
Fixes #380

## Description

Fixes a performance issue in large galleries. Root cause was lucide being called way too much.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [X] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have run `make pr-check` and all checks passed
    - Lint fixes: ✓
    - Tests: ✓
    - Race detector: ✓

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
