### PR TITLE
feat(frontend): when the Lightbox closes, you should be at that item in the gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat(frontend): Closing the lightbox after navigating through images now scrolls the gallery back to the item that was open, keeping it centred in the viewport. Previously the gallery remained at the scroll position from when the lightbox was first opened. [#420](https://github.com/djryanj/media-viewer/issues/420)
 - feat(frontend): Swiping down in the lightbox now closes it. The lightbox follows the finger in real time, fading slightly as it moves. Releasing before the threshold (120 px or 30 % of screen height) or reversing direction snaps it back; releasing past the threshold or flicking quickly (≥ 0.5 px/ms) slides it off screen and closes it. A fast swipe in the opposite direction (horizontal) is unaffected — the gesture recogniser commits to horizontal or vertical on the first 10 px of movement, keeping swipe-navigation and swipe-to-close mutually exclusive. [#419](https://github.com/djryanj/media-viewer/issues/419)
 
 ### Changed

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -1761,6 +1761,23 @@ const Lightbox = {
 
         this.elements.lightbox.classList.add('hidden');
         document.body.style.overflow = '';
+
+        // Scroll the gallery so the item that was open is centred in the viewport.
+        // Only applicable when the lightbox was opened from the main gallery (not
+        // a playlist or search-result pop-up).  A requestAnimationFrame lets the
+        // browser finish restoring body overflow before we change scrollY.
+        if (this.useAppMedia) {
+            const currentItem = this.items[this.currentIndex];
+            if (currentItem?.path) {
+                requestAnimationFrame(() => {
+                    const el = document.querySelector(
+                        `.gallery-item[data-path="${CSS.escape(currentItem.path)}"]`
+                    );
+                    el?.scrollIntoView({ block: 'center', behavior: 'instant' });
+                });
+            }
+        }
+
         this.abortCurrentLoad();
         this.clearPreloadCache();
         this.stopAnimationLoopDetection();

--- a/static/tests/unit/lightbox.test.js
+++ b/static/tests/unit/lightbox.test.js
@@ -1747,6 +1747,114 @@ describe('Lightbox Module', () => {
 
             expect(Lightbox.tagsDrawerOpen).toBe(false);
         });
+
+        describe('close() scroll restoration', () => {
+            let rafSpy;
+
+            beforeEach(() => {
+                // Execute rAF callbacks synchronously so tests are fully sync
+                rafSpy = vi.fn((cb) => {
+                    cb();
+                    return 0;
+                });
+                vi.stubGlobal('requestAnimationFrame', rafSpy);
+
+                Lightbox.items = [
+                    { path: '/gallery/a.jpg', name: 'a.jpg', type: 'image' },
+                    { path: '/gallery/b.jpg', name: 'b.jpg', type: 'image' },
+                    { path: '/gallery/c.jpg', name: 'c.jpg', type: 'image' },
+                ];
+                Lightbox.currentIndex = 1;
+                Lightbox.useAppMedia = true;
+            });
+
+            afterEach(() => {
+                vi.unstubAllGlobals();
+            });
+
+            test('scrolls current item into view on close', () => {
+                const el = document.createElement('div');
+                el.className = 'gallery-item';
+                el.dataset.path = '/gallery/b.jpg';
+                const scrollSpy = vi.fn();
+                el.scrollIntoView = scrollSpy;
+                document.body.appendChild(el);
+
+                Lightbox.close();
+
+                expect(scrollSpy).toHaveBeenCalledOnce();
+                expect(scrollSpy).toHaveBeenCalledWith({ block: 'center', behavior: 'instant' });
+
+                el.remove();
+            });
+
+            test('scrolls to the item at currentIndex, not the opening index', () => {
+                // User navigated from index 1 to index 2 inside the lightbox
+                Lightbox.currentIndex = 2;
+
+                const elB = document.createElement('div');
+                elB.className = 'gallery-item';
+                elB.dataset.path = '/gallery/b.jpg';
+                const scrollB = vi.fn();
+                elB.scrollIntoView = scrollB;
+
+                const elC = document.createElement('div');
+                elC.className = 'gallery-item';
+                elC.dataset.path = '/gallery/c.jpg';
+                const scrollC = vi.fn();
+                elC.scrollIntoView = scrollC;
+
+                document.body.appendChild(elB);
+                document.body.appendChild(elC);
+
+                Lightbox.close();
+
+                expect(scrollC).toHaveBeenCalledOnce();
+                expect(scrollB).not.toHaveBeenCalled();
+
+                elB.remove();
+                elC.remove();
+            });
+
+            test('does not scroll when useAppMedia is false', () => {
+                Lightbox.useAppMedia = false;
+
+                const el = document.createElement('div');
+                el.className = 'gallery-item';
+                el.dataset.path = '/gallery/b.jpg';
+                const scrollSpy = vi.fn();
+                el.scrollIntoView = scrollSpy;
+                document.body.appendChild(el);
+
+                Lightbox.close();
+
+                expect(rafSpy).not.toHaveBeenCalled();
+                expect(scrollSpy).not.toHaveBeenCalled();
+
+                el.remove();
+            });
+
+            test('does not throw when gallery item is not in the DOM', () => {
+                // The DOM has no matching .gallery-item for the current path
+                expect(() => Lightbox.close()).not.toThrow();
+            });
+
+            test('does not scroll when items array is empty', () => {
+                Lightbox.items = [];
+                Lightbox.currentIndex = 0;
+
+                expect(() => Lightbox.close()).not.toThrow();
+                expect(rafSpy).not.toHaveBeenCalled();
+            });
+
+            test('does not scroll when current item has no path', () => {
+                Lightbox.items = [{ name: 'no-path.jpg', type: 'image' }];
+                Lightbox.currentIndex = 0;
+
+                expect(() => Lightbox.close()).not.toThrow();
+                expect(rafSpy).not.toHaveBeenCalled();
+            });
+        });
     });
 
     // =========================================


### PR DESCRIPTION
## Description

Closing the lightbox after navigating through images now scrolls the gallery back to the item that was open, keeping it centred in the viewport. Previously the gallery remained at the scroll position from when the lightbox was first opened.

Closes #420

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [X] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have run `make pr-check` and all checks passed
    - Lint fixes: ✓
    - Tests: ✓
    - Race detector: ✓

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
