### PR TITLE
fix(backend): server startup improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [0.15.6] - Unreleased
+
+### Changed
+
+- fix(backend): Server startup no longer blocks the health check for an entire index run. If a database exists with items, it returns healthy as soon as the server is online. If it's a new database, the health check will block for 500 items indexed, 30 seconds, or the index being completed, whichever is shorter. The indexer also logs much better what it's doing, whereas before it was kind of a black hole. [#436](https://github.com/djryanj/media-viewer/issues/436)
+
 ## [0.15.5] - 03-07-2026
 
 ### Added

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -787,6 +787,7 @@ type BatchInserter struct {
 	del       *sql.Stmt
 	startTime time.Time
 	txType    string // metric label used on successful commit (e.g. "batch_insert", "cleanup")
+	runTime   int64  // Unix timestamp passed as updated_at for every upsert in this batch
 }
 
 // SetTxType sets the metric label that will be used for the successful-commit
@@ -797,9 +798,28 @@ func (b *BatchInserter) SetTxType(t string) {
 	b.txType = t
 }
 
+// SetRunTime sets the Unix timestamp that will be stored in updated_at for every
+// UpsertFile call on this batch.  It must be called before the first UpsertFile.
+// Using a caller-supplied value instead of strftime('now') makes the run-marker
+// deterministic regardless of when each individual statement executes.
+func (b *BatchInserter) SetRunTime(t int64) {
+	b.runTime = t
+}
+
+// upsertQuery inserts or updates a file record.
+//
+// updated_at is supplied as an explicit Go-issued parameter (the indexTime Unix
+// second captured before the index run begins).  Using a caller-supplied value
+// rather than strftime('%s','now') makes the run-marker deterministic: every
+// file touched by the same index run carries the same updated_at value,
+// regardless of how long the upserts take.  The cleanup step then reliably
+// removes rows whose updated_at is strictly less than indexTime.Unix().
+//
+// content_updated_at tracks actual content changes and continues to use
+// strftime('now') so it reflects real modification time.
 const upsertQuery = `
 	INSERT INTO files (name, path, parent_path, type, size, mod_time, mime_type, file_hash, updated_at, content_updated_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, strftime('%s', 'now'), strftime('%s', 'now'))
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s', 'now'))
 	ON CONFLICT(path) DO UPDATE SET
 		name = excluded.name,
 		type = excluded.type,
@@ -807,7 +827,7 @@ const upsertQuery = `
 		mod_time = excluded.mod_time,
 		mime_type = excluded.mime_type,
 		file_hash = excluded.file_hash,
-		updated_at = strftime('%s', 'now'),
+		updated_at = excluded.updated_at,
 		content_updated_at = CASE
 			WHEN files.size != excluded.size
 			  OR files.mod_time != excluded.mod_time
@@ -868,6 +888,8 @@ func (b *BatchInserter) StartTime() time.Time {
 }
 
 // UpsertFile inserts or updates a file record using the pre-prepared statement.
+// The updated_at column is set to b.runTime (set via SetRunTime) so that all
+// files touched by the same index run share a single, Go-controlled timestamp.
 func (b *BatchInserter) UpsertFile(ctx context.Context, file *MediaFile) error {
 	done := b.db.observeQuery("upsert_file")
 
@@ -880,6 +902,7 @@ func (b *BatchInserter) UpsertFile(ctx context.Context, file *MediaFile) error {
 		file.ModTime.Unix(),
 		file.MimeType,
 		file.FileHash,
+		b.runTime,
 	)
 	done(err)
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -23,8 +23,11 @@ const (
 	// Number of files to process before committing a batch
 	batchSize = 500
 
-	// Minimum files to index before marking server as ready
-	minFilesForReady = 100
+	// Minimum items to index before marking an empty database as ready
+	minFilesForReady = 500
+
+	// Maximum time to block health checks when starting with an empty database
+	startupReadyTimeout = 30 * time.Second
 
 	// Delay between batches to allow other operations
 	batchDelay = 10 * time.Millisecond
@@ -52,12 +55,23 @@ type Indexer struct {
 	foldersIndexed atomic.Int64
 	indexProgress  atomic.Value
 
+	// currentRunTime is the Unix timestamp stamped onto every upsert's
+	// updated_at column for the duration of the active index run.  It is set
+	// once per run (after the second-boundary sleep) and read by every
+	// processBatch call, which all execute in the same goroutine.
+	currentRunTime atomic.Int64
+
 	// Parallel walker configuration
 	parallelConfig ParallelWalkerConfig
 	useParallel    bool
 
 	// Callback when indexing completes
 	onIndexComplete func()
+
+	// Number of items in the database at the time Start() was called.
+	// When > 0 the server is considered immediately ready, since users can
+	// already browse existing content while the background re-index runs.
+	startupDBCount int64
 
 	// Last known state for lightweight change detection
 	stateMu            sync.RWMutex
@@ -115,6 +129,19 @@ func (idx *Indexer) SetOnIndexComplete(callback func()) {
 
 // Start begins the indexing process.
 func (idx *Indexer) Start() error {
+	// Check how many items are already in the database.  If the database is
+	// non-empty the server is immediately ready for traffic; the background
+	// re-index updates stale entries without blocking the health check.
+	if stats, err := idx.db.CalculateStats(); err == nil {
+		idx.startupDBCount = int64(stats.TotalFiles + stats.TotalFolders)
+	}
+	if idx.startupDBCount > 0 {
+		logging.Info("Database has %d existing items — health check will not block during re-index", idx.startupDBCount)
+	} else {
+		logging.Info("Empty database — health check will block for up to %v or %d items indexed",
+			startupReadyTimeout, minFilesForReady)
+	}
+
 	// Start initial index in background
 	go func() {
 		logging.Info("Starting initial index in background...")
@@ -141,7 +168,23 @@ func (idx *Indexer) Stop() {
 }
 
 // IsReady returns true if the server is ready to accept traffic.
+//
+// Non-blocking rules (applied in order):
+//  1. If the database already had items before startup, return true immediately
+//     so that a background re-index never blocks the health check.
+//  2. For an empty database, block until the startup timeout elapses, enough
+//     items have been indexed, or the initial index finishes — whichever comes
+//     first.
 func (idx *Indexer) IsReady() bool {
+	// Rule 1: existing data — never block.
+	if idx.startupDBCount > 0 {
+		return true
+	}
+
+	// Rule 2: empty database — apply startup caps.
+	if time.Since(idx.startTime) >= startupReadyTimeout {
+		return true
+	}
 	if idx.filesIndexed.Load()+idx.foldersIndexed.Load() >= minFilesForReady {
 		return true
 	}
@@ -167,7 +210,10 @@ func (idx *Indexer) GetHealthStatus() HealthStatus {
 	progress := idx.getProgress()
 
 	status := HealthStatus{
-		Ready:          idx.initialIndexComplete || (idx.filesIndexed.Load()+idx.foldersIndexed.Load() >= minFilesForReady),
+		Ready: idx.startupDBCount > 0 ||
+			idx.initialIndexComplete ||
+			idx.filesIndexed.Load()+idx.foldersIndexed.Load() >= minFilesForReady ||
+			time.Since(idx.startTime) >= startupReadyTimeout,
 		Indexing:       idx.isIndexing,
 		StartTime:      idx.startTime,
 		Uptime:         time.Since(idx.startTime).String(),
@@ -419,6 +465,29 @@ func (idx *Indexer) Index() error {
 	// concurrent read queries crawl even in WAL mode.  By dropping the triggers now
 	// and doing a single bulk rebuild at the end we reduce write amplification from
 	// O(n) to O(1) for FTS.
+	// Advance to the next Unix-second boundary before capturing indexTime.
+	// SQLite stores updated_at at second precision (strftime('%s','now')), so
+	// every file upserted in this run will have updated_at = T where T is the
+	// current second when the upsert executes.  The cleanup query deletes rows
+	// with updated_at < indexTime.Unix(), so indexTime must be > T for any file
+	// from a previous run. By sleeping until the next second boundary we
+	// guarantee that indexTime.Unix() = T+1 while all current-run upserts land
+	// in second T+1 as well — so "updated_at < T+1" reliably targets only files
+	// that were last touched before this run began.
+	// Sleep to the next Unix-second boundary so that indexTime.Unix() is
+	// guaranteed to be strictly greater than indexTime.Unix() from the previous
+	// run (even when two runs complete within the same wall-clock second).
+	// This second value is then stamped onto every upsert's updated_at column
+	// (via currentRunTime / SetRunTime), making the cleanup delete condition
+	// "updated_at < indexTime.Unix()" deterministic regardless of how long
+	// individual SQLite statements take to execute.
+	now := time.Now()
+	if remaining := time.Until(now.Truncate(time.Second).Add(time.Second)); remaining > 0 {
+		time.Sleep(remaining + 2*time.Millisecond)
+	}
+	indexTime := time.Now()
+	idx.currentRunTime.Store(indexTime.Unix())
+
 	bulkCtx := context.Background()
 	if err := idx.db.BulkIndexBegin(bulkCtx); err != nil {
 		// Non-fatal: log and continue.  Indexing will still work, just slower.
@@ -426,8 +495,6 @@ func (idx *Indexer) Index() error {
 	} else {
 		logging.Debug("FTS triggers disabled for bulk index run")
 	}
-
-	indexTime := time.Now()
 
 	var result indexResult
 	var err error
@@ -679,10 +746,15 @@ func (idx *Indexer) processPath(
 
 		time.Sleep(batchDelay)
 
+		// Log progress every 500 items (every batch) with throughput.
 		total := result.totalFiles + result.totalFolders
-		if total%5000 == 0 {
-			logging.Info("Indexed %d files, %d folders...", result.totalFiles, result.totalFolders)
+		elapsed := time.Since(startTime)
+		itemsPerSecond := 0.0
+		if elapsed.Seconds() > 0 {
+			itemsPerSecond = float64(total) / elapsed.Seconds()
 		}
+		logging.Info("Indexing progress: %d files, %d folders (%.0f items/s)",
+			result.totalFiles, result.totalFolders, itemsPerSecond)
 	}
 
 	return nil
@@ -771,6 +843,9 @@ func (idx *Indexer) finalizeIndex(startTime time.Time, totalFiles, totalFolders 
 }
 
 // processBatch processes a batch of files in a single transaction.
+// Every upsert is stamped with idx.currentRunTime so that updated_at is a
+// Go-controlled value rather than SQLite's strftime('now'), which can vary
+// across batches when the race detector slows execution.
 func (idx *Indexer) processBatch(files []database.MediaFile) error {
 	if len(files) == 0 {
 		return nil
@@ -784,6 +859,7 @@ func (idx *Indexer) processBatch(files []database.MediaFile) error {
 		return fmt.Errorf("failed to begin batch transaction: %w", err)
 	}
 	batch.SetTxType("batch_insert")
+	batch.SetRunTime(idx.currentRunTime.Load())
 
 	for i := range files {
 		if err := batch.UpsertFile(ctx, &files[i]); err != nil {

--- a/internal/indexer/indexer_integration_test.go
+++ b/internal/indexer/indexer_integration_test.go
@@ -430,11 +430,15 @@ func TestIndexerIncrementalUpdatesIntegration(t *testing.T) {
 		t.Fatalf("Failed to delete file: %v", err)
 	}
 
-	// Wait to ensure timestamps differ significantly for cleanup to work
-	// The cleanup compares file updated_at times (set during index) with indexTime (captured at start of index).
-	// Since files get updated_at set to current database time during processing, we need enough delay
-	// so the third index's indexTime is after all files' updated_at from the second index.
-	time.Sleep(1100 * time.Millisecond)
+	// Ensure the third index run's boundary sleep produces an indexTime.Unix()
+	// value strictly greater than the second run's indexTime.Unix().
+	// Each Index() call sleeps to the next Unix-second boundary, so waiting
+	// for 2 full seconds guarantees a fresh second for run 3's marker.
+	waitStart := time.Now()
+	targetSecond := waitStart.Unix() + 2
+	for time.Now().Unix() < targetSecond {
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	// Third index (should remove deleted file)
 	if err := idx.Index(); err != nil {
@@ -534,8 +538,15 @@ func TestIndexerStopAndRestartIntegration(t *testing.T) {
 	// Start and run index
 	idx.Start()
 
-	// Wait for initial index
-	time.Sleep(500 * time.Millisecond)
+	// Wait for initial index to complete. Index() sleeps up to ~1s at startup
+	// (next Unix-second boundary), so poll instead of using a fixed sleep.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !idx.LastIndexTime().IsZero() {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	// Stop indexer
 	idx.Stop()

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -296,8 +296,9 @@ func TestIndexerConstants(t *testing.T) {
 	})
 
 	t.Run("minFilesForReady", func(_ *testing.T) {
-		// Expected: 100 files minimum before server is ready
-		// Ensures initial index has made progress
+		// Expected: 500 items minimum before an empty-database server is ready
+		// Paired with startupReadyTimeout (30s) — whichever fires first unblocks
+		// the health check when the database is empty on first start.
 	})
 
 	t.Run("batchDelay", func(_ *testing.T) {
@@ -394,7 +395,7 @@ func TestHealthStatusReady(t *testing.T) {
 	}{
 		{
 			name:            "Ready with enough files",
-			filesIndexed:    100,
+			filesIndexed:    490,
 			foldersIndexed:  10,
 			initialComplete: false,
 			wantReady:       true,
@@ -420,7 +421,7 @@ func TestHealthStatusReady(t *testing.T) {
 			// Note: This documents the expected behavior
 			// Actual IsReady() implementation checks these conditions
 			totalIndexed := tt.filesIndexed + tt.foldersIndexed
-			isReady := (totalIndexed >= 100) || tt.initialComplete
+			isReady := (totalIndexed >= minFilesForReady) || tt.initialComplete
 
 			if isReady != tt.wantReady {
 				t.Errorf("Expected ready=%v, got %v", tt.wantReady, isReady)
@@ -713,34 +714,81 @@ func TestIsReady(t *testing.T) {
 	db := &database.Database{}
 	idx := New(db, tempDir, 5*time.Minute)
 
-	// Not ready initially
+	// Not ready initially (empty DB, no items indexed yet)
 	if idx.IsReady() {
 		t.Error("Expected IsReady=false initially")
 	}
 
-	// Not ready with few files
-	idx.filesIndexed.Store(50)
-	idx.foldersIndexed.Store(5)
+	// Not ready with fewer than minFilesForReady items
+	idx.filesIndexed.Store(400)
+	idx.foldersIndexed.Store(50)
 	if idx.IsReady() {
-		t.Error("Expected IsReady=false with only 55 items")
+		t.Error("Expected IsReady=false with only 450 items (< 500)")
 	}
 
-	// Ready with enough files
-	idx.filesIndexed.Store(95)
+	// Ready once minFilesForReady items are indexed
+	idx.filesIndexed.Store(490)
 	idx.foldersIndexed.Store(10)
 	if !idx.IsReady() {
-		t.Error("Expected IsReady=true with 105 items")
+		t.Error("Expected IsReady=true with 500 items")
 	}
 
-	// Reset and test with initial complete flag
+	// Reset and test with initialIndexComplete flag
 	idx.filesIndexed.Store(0)
 	idx.foldersIndexed.Store(0)
 	idx.indexMu.Lock()
 	idx.initialIndexComplete = true
 	idx.indexMu.Unlock()
-
 	if !idx.IsReady() {
 		t.Error("Expected IsReady=true with initialIndexComplete=true")
+	}
+}
+
+// TestIsReadyWithExistingDatabase verifies that when the database already held
+// items at startup (startupDBCount > 0) the server is immediately ready,
+// regardless of how many items have been indexed in the current run.
+func TestIsReadyWithExistingDatabase(t *testing.T) {
+	tempDir := t.TempDir()
+	db := &database.Database{}
+	idx := New(db, tempDir, 5*time.Minute)
+
+	// Simulate a non-empty database at startup time
+	idx.startupDBCount = 1234
+
+	// Should be immediately ready even with zero items indexed so far
+	if !idx.IsReady() {
+		t.Error("Expected IsReady=true when startupDBCount > 0")
+	}
+
+	// Confirm GetHealthStatus agrees
+	status := idx.GetHealthStatus()
+	if !status.Ready {
+		t.Error("Expected GetHealthStatus.Ready=true when startupDBCount > 0")
+	}
+}
+
+// TestIsReadyAfterStartupTimeout verifies that the server becomes ready once
+// startupReadyTimeout has elapsed, even if fewer than minFilesForReady items
+// have been indexed and the initial index is not yet complete.
+func TestIsReadyAfterStartupTimeout(t *testing.T) {
+	tempDir := t.TempDir()
+	db := &database.Database{}
+	idx := New(db, tempDir, 5*time.Minute)
+
+	// Backdate startTime to simulate the timeout having elapsed
+	idx.startTime = time.Now().Add(-(startupReadyTimeout + time.Second))
+
+	// Only a handful of files indexed, initial index not complete
+	idx.filesIndexed.Store(10)
+
+	if !idx.IsReady() {
+		t.Error("Expected IsReady=true after startupReadyTimeout has elapsed")
+	}
+
+	// Confirm GetHealthStatus agrees
+	status := idx.GetHealthStatus()
+	if !status.Ready {
+		t.Error("Expected GetHealthStatus.Ready=true after timeout")
 	}
 }
 
@@ -1126,14 +1174,14 @@ func TestGetHealthStatusWhileIndexing(t *testing.T) {
 	db := &database.Database{}
 	idx := New(db, tempDir, 5*time.Minute)
 
-	// Simulate indexing in progress
+	// Simulate indexing in progress with enough items to cross minFilesForReady
 	idx.indexMu.Lock()
 	idx.isIndexing = true
 	idx.indexMu.Unlock()
-	idx.filesIndexed.Store(150)
+	idx.filesIndexed.Store(480)
 	idx.foldersIndexed.Store(20)
 	idx.indexProgress.Store(IndexProgress{
-		FilesIndexed:   150,
+		FilesIndexed:   480,
 		FoldersIndexed: 20,
 		IsIndexing:     true,
 		StartedAt:      time.Now(),
@@ -1142,13 +1190,13 @@ func TestGetHealthStatusWhileIndexing(t *testing.T) {
 	status := idx.GetHealthStatus()
 
 	if !status.Ready {
-		t.Error("Expected Ready=true (150+20=170 >= 100)")
+		t.Error("Expected Ready=true (480+20=500 >= minFilesForReady)")
 	}
 	if !status.Indexing {
 		t.Error("Expected Indexing=true")
 	}
-	if status.FilesIndexed != 150 {
-		t.Errorf("Expected FilesIndexed=150, got %d", status.FilesIndexed)
+	if status.FilesIndexed != 480 {
+		t.Errorf("Expected FilesIndexed=480, got %d", status.FilesIndexed)
 	}
 	if status.FoldersIndexed != 20 {
 		t.Errorf("Expected FoldersIndexed=20, got %d", status.FoldersIndexed)

--- a/internal/indexer/parallel.go
+++ b/internal/indexer/parallel.go
@@ -119,6 +119,8 @@ func (pw *ParallelWalker) Walk() ([]database.MediaFile, error) {
 	var collectorErr error
 	var mu sync.Mutex
 
+	var walkCount int64
+
 	collectorWg.Add(1)
 	go func() {
 		defer collectorWg.Done()
@@ -132,6 +134,17 @@ func (pw *ParallelWalker) Walk() ([]database.MediaFile, error) {
 				mu.Lock()
 				allFiles = append(allFiles, *result.file)
 				mu.Unlock()
+
+				n := atomic.AddInt64(&walkCount, 1)
+				if n%500 == 0 {
+					elapsed := time.Since(startTime)
+					itemsPerSecond := 0.0
+					if elapsed.Seconds() > 0 {
+						itemsPerSecond = float64(n) / elapsed.Seconds()
+					}
+					logging.Info("Walk progress: %d items discovered (%.0f items/s)",
+						n, itemsPerSecond)
+				}
 			}
 		}
 	}()

--- a/internal/media/thumbnail_integration_test.go
+++ b/internal/media/thumbnail_integration_test.go
@@ -2361,6 +2361,7 @@ func upsertTestFile(ctx context.Context, t *testing.T, db *database.Database, fi
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
+	batch.SetRunTime(time.Now().Unix())
 	upsertErr := batch.UpsertFile(ctx, &file)
 	if err := db.EndBatch(batch, upsertErr); err != nil {
 		t.Fatalf("UpsertFile failed: %v", err)
@@ -2463,6 +2464,7 @@ func deleteTestFile(ctx context.Context, t *testing.T, db *database.Database, ke
 	if err != nil {
 		t.Fatalf("BeginBatch failed: %v", err)
 	}
+	batch.SetRunTime(cutoff.Unix())
 
 	for i := range keepFiles {
 		if upsertErr := batch.UpsertFile(ctx, &keepFiles[i]); upsertErr != nil {


### PR DESCRIPTION
## Description

Improves the server startup experience, especially for large and pre-existing libraries. Server startup no longer blocks the health check for an entire index run. If a database exists with items, it returns healthy as soon as the server is online. If it's a new database, the health check will block for 500 items indexed, 30 seconds, or the index being completed, whichever is shorter. The indexer also logs much better what it's doing, whereas before it was kind of a black hole. 

Fixes #436 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [ ] Frontend/UI
- [X] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [X] Search/Indexing
- [ ] Tags
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have run `make pr-check` and all checks passed
    - Lint fixes: ✓
    - Tests: ✓
    - Race detector: ✓

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
