### PR TITLE
fix(backend): centralize autotagger tool checks and logs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,6 +49,11 @@ Use these as project-level defaults when editing or testing this repository.
 - SQLite mmap is auto-disabled in startup when `DATABASE_DIR` resolves to detected unsafe Linux filesystems such as NFS, SMB/CIFS, or 9P/WSL. Preserve that behavior when changing startup or database initialization.
 - Explicit `DB_MMAP_DISABLED=true` or `false` still overrides the auto-detection path; keep that override behavior intact.
 
+## Startup Logging
+
+- Keep startup-time component initialization banners and required-tool availability logs centralized in `internal/startup` rather than emitting them from runtime component packages.
+- EXIF auto-tagger startup logging should follow the same pattern as transcoder and thumbnail initialization: `internal/startup` owns the initialization section and tool checks, while `internal/autotagger` keeps ongoing runtime/pass logs only.
+
 ## UI And UX Guardrails
 
 - Collections UX should follow the same patterns as tags/favorites instead of inventing separate one-off interaction models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] - Unreleased
+
+### Fixed
+
+- fix(backend): Startup logs now report `exiftool` and `ffprobe` availability alongside the rest of the server's initialization checks, making it easier to confirm metadata extraction readiness in local and container deployments. The startup logging for these checks is also now centralized so component initialization output stays consistent. ([#507](https://github.com/djryanj/media-viewer/issues/507))
+
 ## [0.17.2] - 04-11-2026
 
 ### Fixed

--- a/cmd/media-viewer/main.go
+++ b/cmd/media-viewer/main.go
@@ -143,6 +143,7 @@ func main() {
 	idx.SetPollInterval(config.PollInterval)
 
 	// Initialize EXIF auto-tagger
+	startup.LogAutoTaggerInit(config.ExifTaggingEnabled, config.ExifTagInterval)
 	autoTagger := autotagger.New(db, config.MediaDir, config.ExifTagInterval, config.ExifTaggingEnabled)
 
 	idx.SetOnIndexComplete(func() {
@@ -164,6 +165,9 @@ func main() {
 
 	// Start EXIF auto-tagger in background
 	autoTagger.Start()
+	if config.ExifTaggingEnabled {
+		startup.LogAutoTaggerStarted()
+	}
 
 	// Start metrics collector
 	metricsCollector := metrics.NewCollector(&dbStatsAdapter{db: db}, config.DatabasePath, 1*time.Minute)

--- a/internal/autotagger/autotagger.go
+++ b/internal/autotagger/autotagger.go
@@ -3,7 +3,6 @@ package autotagger
 import (
 	"context"
 	"errors"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -90,27 +89,10 @@ func (a *AutoTagger) NotifyIndexComplete() {
 // tagger is disabled.
 func (a *AutoTagger) Start() {
 	if !a.enabled {
-		logging.Info("EXIF auto-tagging disabled")
 		return
 	}
-	logMetadataToolAvailability()
 	logging.Debug("AutoTagger: enabled for media dir %s", a.mediaDir)
-	logging.Info("EXIF auto-tagger started (interval: %v)", a.interval)
 	go a.loop()
-}
-
-func logMetadataToolAvailability() {
-	if exiftoolPath, err := exec.LookPath("exiftool"); err != nil {
-		logging.Warn("AutoTagger: exiftool not found in PATH; still-image metadata extraction will fall back to ffprobe only")
-	} else {
-		logging.Debug("AutoTagger: using exiftool at %s", exiftoolPath)
-	}
-
-	if ffprobePath, err := exec.LookPath("ffprobe"); err != nil {
-		logging.Warn("AutoTagger: ffprobe not found in PATH; video metadata extraction will fail and still-image fallback will be unavailable")
-	} else {
-		logging.Debug("AutoTagger: using ffprobe at %s", ffprobePath)
-	}
 }
 
 // TriggerRun launches an on-demand full (non-incremental) pass in the

--- a/internal/startup/doc.go
+++ b/internal/startup/doc.go
@@ -46,6 +46,7 @@
 //   - [LogDatabaseInit]: Database initialization timing
 //   - [LogTranscoderInit]: Transcoder setup and FFmpeg availability
 //   - [LogThumbnailInit]: Thumbnail generator configuration
+//   - [LogAutoTaggerInit]: Auto-tagger setup and metadata tool availability
 //   - [LogIndexerInit]: Indexer configuration and intervals
 //   - [LogHTTPRoutes]: Registered HTTP routes (debug level)
 //   - [LogServerStarted]: Server endpoints and startup duration

--- a/internal/startup/startup.go
+++ b/internal/startup/startup.go
@@ -515,6 +515,40 @@ func LogThumbnailInit(enabled bool) {
 	logging.Info("  libvips will be initialized for memory-efficient image processing")
 }
 
+// LogAutoTaggerInit logs auto-tagger initialization and required metadata tools.
+func LogAutoTaggerInit(enabled bool, interval time.Duration) {
+	logging.Info("")
+	logging.Info("------------------------------------------------------------")
+	logging.Info("AUTO-TAGGER INITIALIZATION")
+	logging.Info("------------------------------------------------------------")
+
+	if !enabled {
+		logging.Info("  EXIF auto-tagging disabled")
+		return
+	}
+
+	logging.Info("  Auto-tag interval: %v", interval)
+
+	if err := checkExiftool(); err != nil {
+		logging.Warn("  exiftool check failed: %v", err)
+		logging.Warn("  Still-image metadata extraction will fall back to ffprobe only")
+	} else {
+		logging.Info("  [OK] exiftool is available")
+	}
+
+	if err := checkFFprobe(); err != nil {
+		logging.Warn("  ffprobe check failed: %v", err)
+		logging.Warn("  Video metadata extraction will fail and still-image fallback will be unavailable")
+	} else {
+		logging.Info("  [OK] ffprobe is available")
+	}
+}
+
+// LogAutoTaggerStarted logs successful auto-tagger startup.
+func LogAutoTaggerStarted() {
+	logging.Info("  [OK] EXIF auto-tagger started")
+}
+
 // LogIndexerInit logs indexer initialization
 func LogIndexerInit(indexInterval, pollInterval time.Duration) {
 	logging.Info("")
@@ -815,7 +849,7 @@ func checkFFmpeg() error {
 	if err != nil {
 		return fmt.Errorf("ffmpeg not found in PATH")
 	}
-	logging.Debug("  FFmpeg path: %s", path)
+	logging.Debug("  ffmpeg path: %s", path)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -826,12 +860,55 @@ func checkFFmpeg() error {
 		return fmt.Errorf("failed to get ffmpeg version: %w", err)
 	}
 
-	lines := strings.Split(string(output), "\n")
-	if len(lines) > 0 {
-		logging.Debug("  FFmpeg version: %s", strings.TrimSpace(lines[0]))
+	logToolVersionLine("ffmpeg", output)
+	return nil
+}
+
+func checkFFprobe() error {
+	path, err := exec.LookPath("ffprobe")
+	if err != nil {
+		return fmt.Errorf("ffprobe not found in PATH")
+	}
+	logging.Debug("  ffprobe path: %s", path)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ffprobe", "-version")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get ffprobe version: %w", err)
 	}
 
+	logToolVersionLine("ffprobe", output)
 	return nil
+}
+
+func checkExiftool() error {
+	path, err := exec.LookPath("exiftool")
+	if err != nil {
+		return fmt.Errorf("exiftool not found in PATH")
+	}
+	logging.Debug("  exiftool path: %s", path)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "exiftool", "-ver")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get exiftool version: %w", err)
+	}
+
+	logToolVersionLine("exiftool", output)
+	return nil
+}
+
+func logToolVersionLine(tool string, output []byte) {
+	lines := strings.Split(string(output), "\n")
+	if len(lines) > 0 {
+		logging.Debug("  %s version: %s", tool, strings.TrimSpace(lines[0]))
+	}
 }
 
 func getEnv(key, defaultValue string) string {

--- a/internal/startup/startup_test.go
+++ b/internal/startup/startup_test.go
@@ -1099,6 +1099,19 @@ func TestLogThumbnailInitEnabled(_ *testing.T) {
 	LogThumbnailInit(true)
 }
 
+func TestLogAutoTaggerInitDisabled(_ *testing.T) {
+	LogAutoTaggerInit(false, 24*time.Hour)
+}
+
+func TestLogAutoTaggerInitEnabled(_ *testing.T) {
+	// Metadata tools may or may not be present; the function must not panic either way.
+	LogAutoTaggerInit(true, 24*time.Hour)
+}
+
+func TestLogAutoTaggerStarted(_ *testing.T) {
+	LogAutoTaggerStarted()
+}
+
 func TestLogIndexerInit(_ *testing.T) {
 	LogIndexerInit(30*time.Minute, 30*time.Second)
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Fixes #507 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [ ] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags / AutoTagger
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [x] Other: **\_**

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have run `make pr-check` and all relevant checks passed
    - Backend changes: `make lint`, `make test`, and `make test-race`
    - Frontend changes: `make frontend-check`, `make frontend-test-unit`, `make frontend-test-integration-auto`, and `make frontend-test-e2e-smoke-auto`
- [x] If I needed Go lint autofixes before rerunning checks, I used `make pr-check-fix`

### Frontend PR Checks

- [ ] If this PR changes frontend flows outside the smoke subset, I also ran broader or focused browser coverage such as `make frontend-test-e2e`, `make frontend-test-e2e-file <spec>`, or `make frontend-test-e2e-module <tag>`
- [ ] If this PR intentionally changes UI presentation, I ran `make frontend-test-e2e-visual`
- [ ] If this PR intentionally changes committed visual baselines, I ran `make frontend-test-e2e-visual-baselines` and included the updated artifacts
- [ ] If this PR refreshes documentation imagery, I ran `make frontend-test-e2e-docs-screenshots` and included the updated `docs/images/` assets
- [ ] If this PR affects performance-sensitive frontend flows, I ran the relevant `make frontend-test-e2e-performance*` lane

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
