### PR TITLE
fix: The UI jumps around a lot after 0.18.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:24-trixie
+
+ARG GO_VERSION=1.26.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    g++ \
+    gcc \
+    git \
+    libc6-dev \
+    make \
+    pkg-config \
+    tar \
+    && rm -rf /var/lib/apt/lists/* \
+    && arch="$(dpkg --print-architecture)" \
+    && case "${arch}" in \
+    amd64) go_arch='amd64' ;; \
+    arm64) go_arch='arm64' ;; \
+    *) echo "Unsupported architecture: ${arch}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL -o /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" \
+    && rm -rf /usr/local/go \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm -f /tmp/go.tar.gz \
+    && mkdir -p /go/bin /go/pkg /go/src \
+    && chown -R node:node /go
+
+ENV GOPATH=/go
+ENV PATH=/usr/local/go/bin:/go/bin:${PATH}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,11 +5,6 @@
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
       "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
     },
-    "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.3.3",
-      "resolved": "ghcr.io/devcontainers/features/go@sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1",
-      "integrity": "sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1"
-    },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "1.8.0",
       "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,11 @@
 {
     "name": "Media Viewer Dev",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:24-trixie",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
 
     "features": {
-        "ghcr.io/devcontainers/features/go:1": {
-            // renovate: datasource=golang-version depName=go
-            "version": "1.26.2",
-            // renovate: datasource=github-releases depName=golangci/golangci-lint
-            "golangciLintVersion": "2.12.0"
-        },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
             "version": "latest",
             "moby": false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.2] - Unreleased
+
+### Fixed
+
+- fix(frontend): Large library browsing is stable again after the recent gallery windowing changes in v0.18.1. Desktop scrolling no longer flickers, touch scrolling no longer snaps back toward the top, and scrubber jumps now reliably load the requested position instead of stalling partway through the library. ([#542](https://github.com/djryanj/media-viewer/issues/542))
+
 ## [0.18.1] - 05-03-2026
 
 ### Changed

--- a/static/e2e/baselines/tagging/tagging-lightbox-drawer.json
+++ b/static/e2e/baselines/tagging/tagging-lightbox-drawer.json
@@ -603,7 +603,7 @@
         "display": "block",
         "position": "absolute",
         "color": "rgb(234, 234, 234)",
-        "background-color": "rgba(0, 0, 0, 0.19)",
+        "background-color": "rgba(0, 0, 0, 0.357)",
         "border-top-color": "rgb(234, 234, 234)",
         "border-right-color": "rgb(234, 234, 234)",
         "border-bottom-color": "rgb(234, 234, 234)",
@@ -636,10 +636,10 @@
         "open"
       ],
       "rect": {
-        "x": 485,
-        "y": 380,
-        "width": 470,
-        "height": 340
+        "x": 481,
+        "y": 377,
+        "width": 479,
+        "height": 346
       },
       "styles": {
         "display": "flex",
@@ -657,7 +657,7 @@
         "line-height": "24px",
         "letter-spacing": "normal",
         "text-transform": "none",
-        "opacity": "0.576359",
+        "opacity": "0.954495",
         "gap": "normal",
         "align-items": "normal",
         "justify-content": "normal",
@@ -677,10 +677,10 @@
         "drawer-header"
       ],
       "rect": {
-        "x": 485,
-        "y": 380,
-        "width": 470,
-        "height": 56
+        "x": 481,
+        "y": 377,
+        "width": 479,
+        "height": 57
       },
       "styles": {
         "display": "flex",
@@ -719,9 +719,9 @@
       ],
       "text": "Tags",
       "rect": {
-        "x": 505,
-        "y": 397,
-        "width": 55,
+        "x": 501,
+        "y": 394,
+        "width": 56,
         "height": 22
       },
       "styles": {
@@ -760,10 +760,10 @@
         "drawer-close"
       ],
       "rect": {
-        "x": 904,
-        "y": 392,
-        "width": 31,
-        "height": 31
+        "x": 908,
+        "y": 389,
+        "width": 32,
+        "height": 32
       },
       "styles": {
         "display": "flex",
@@ -801,10 +801,10 @@
         "drawer-body"
       ],
       "rect": {
-        "x": 485,
-        "y": 436,
-        "width": 470,
-        "height": 68
+        "x": 481,
+        "y": 434,
+        "width": 479,
+        "height": 69
       },
       "styles": {
         "display": "block",
@@ -842,10 +842,10 @@
         "drawer-tags-list"
       ],
       "rect": {
-        "x": 505,
-        "y": 452,
-        "width": 431,
-        "height": 36
+        "x": 501,
+        "y": 450,
+        "width": 439,
+        "height": 37
       },
       "styles": {
         "display": "flex",
@@ -883,10 +883,10 @@
         "drawer-tag-chip"
       ],
       "rect": {
-        "x": 505,
-        "y": 452,
-        "width": 105,
-        "height": 36
+        "x": 501,
+        "y": 450,
+        "width": 107,
+        "height": 37
       },
       "styles": {
         "display": "flex",
@@ -924,10 +924,10 @@
         "drawer-tag-remove"
       ],
       "rect": {
-        "x": 506,
-        "y": 453,
-        "width": 27,
-        "height": 34
+        "x": 501,
+        "y": 451,
+        "width": 28,
+        "height": 35
       },
       "styles": {
         "display": "flex",
@@ -965,10 +965,10 @@
         "drawer-tag-divider"
       ],
       "rect": {
-        "x": 533,
-        "y": 453,
+        "x": 529,
+        "y": 451,
         "width": 1,
-        "height": 34
+        "height": 35
       },
       "styles": {
         "display": "block",
@@ -1007,10 +1007,10 @@
       ],
       "text": "night-sky",
       "rect": {
-        "x": 534,
-        "y": 453,
-        "width": 74,
-        "height": 34
+        "x": 530,
+        "y": 451,
+        "width": 76,
+        "height": 35
       },
       "styles": {
         "display": "block",
@@ -1048,10 +1048,10 @@
         "drawer-tag-chip"
       ],
       "rect": {
-        "x": 617,
-        "y": 452,
-        "width": 137,
-        "height": 36
+        "x": 615,
+        "y": 450,
+        "width": 139,
+        "height": 37
       },
       "styles": {
         "display": "flex",
@@ -1089,10 +1089,10 @@
         "drawer-tag-remove"
       ],
       "rect": {
-        "x": 618,
-        "y": 453,
-        "width": 27,
-        "height": 34
+        "x": 616,
+        "y": 451,
+        "width": 28,
+        "height": 35
       },
       "styles": {
         "display": "flex",
@@ -1130,10 +1130,10 @@
         "drawer-tag-divider"
       ],
       "rect": {
-        "x": 646,
-        "y": 453,
+        "x": 644,
+        "y": 451,
         "width": 1,
-        "height": 34
+        "height": 35
       },
       "styles": {
         "display": "block",
@@ -1172,10 +1172,10 @@
       ],
       "text": "long-exposure",
       "rect": {
-        "x": 647,
-        "y": 453,
-        "width": 106,
-        "height": 34
+        "x": 645,
+        "y": 451,
+        "width": 108,
+        "height": 35
       },
       "styles": {
         "display": "block",
@@ -1213,10 +1213,10 @@
         "drawer-tag-chip"
       ],
       "rect": {
-        "x": 762,
-        "y": 452,
-        "width": 102,
-        "height": 36
+        "x": 763,
+        "y": 450,
+        "width": 104,
+        "height": 37
       },
       "styles": {
         "display": "flex",
@@ -1254,10 +1254,10 @@
         "drawer-tag-remove"
       ],
       "rect": {
-        "x": 763,
-        "y": 453,
-        "width": 27,
-        "height": 34
+        "x": 764,
+        "y": 451,
+        "width": 28,
+        "height": 35
       },
       "styles": {
         "display": "flex",
@@ -1295,10 +1295,10 @@
         "drawer-tag-divider"
       ],
       "rect": {
-        "x": 790,
-        "y": 453,
+        "x": 792,
+        "y": 451,
         "width": 1,
-        "height": 34
+        "height": 35
       },
       "styles": {
         "display": "block",
@@ -1337,10 +1337,10 @@
       ],
       "text": "favorites",
       "rect": {
-        "x": 791,
-        "y": 453,
-        "width": 71,
-        "height": 34
+        "x": 793,
+        "y": 451,
+        "width": 73,
+        "height": 35
       },
       "styles": {
         "display": "block",
@@ -1378,10 +1378,10 @@
         "drawer-footer"
       ],
       "rect": {
-        "x": 485,
-        "y": 504,
-        "width": 470,
-        "height": 216
+        "x": 481,
+        "y": 503,
+        "width": 479,
+        "height": 220
       },
       "styles": {
         "display": "block",
@@ -1419,10 +1419,10 @@
         "drawer-add-tag"
       ],
       "rect": {
-        "x": 505,
+        "x": 501,
         "y": 516,
-        "width": 431,
-        "height": 39
+        "width": 439,
+        "height": 40
       },
       "styles": {
         "display": "flex",
@@ -1461,22 +1461,22 @@
       ],
       "value": "",
       "rect": {
-        "x": 505,
+        "x": 501,
         "y": 516,
-        "width": 384,
-        "height": 39
+        "width": 391,
+        "height": 40
       },
       "styles": {
         "display": "block",
         "position": "static",
         "color": "rgb(234, 234, 234)",
         "background-color": "rgb(26, 26, 46)",
-        "border-top-color": "rgb(78, 134, 181)",
-        "border-right-color": "rgb(78, 134, 181)",
-        "border-bottom-color": "rgb(78, 134, 181)",
-        "border-left-color": "rgb(78, 134, 181)",
+        "border-top-color": "rgb(93, 172, 225)",
+        "border-right-color": "rgb(93, 172, 225)",
+        "border-bottom-color": "rgb(93, 172, 225)",
+        "border-left-color": "rgb(93, 172, 225)",
         "border-radius": "8px",
-        "box-shadow": "rgba(93, 173, 226, 0.21) 0px 0px 0px 1.41216px",
+        "box-shadow": "rgba(93, 173, 226, 0.3) 0px 0px 0px 1.99224px",
         "font-size": "14px",
         "font-weight": "400",
         "line-height": "21px",
@@ -1504,10 +1504,10 @@
         "drawer-add-btn"
       ],
       "rect": {
-        "x": 896,
+        "x": 900,
         "y": 516,
-        "width": 39,
-        "height": 39
+        "width": 40,
+        "height": 40
       },
       "styles": {
         "display": "flex",
@@ -1545,10 +1545,10 @@
         "drawer-tag-suggestions"
       ],
       "rect": {
-        "x": 505,
+        "x": 501,
         "y": 561,
-        "width": 431,
-        "height": 147
+        "width": 439,
+        "height": 150
       },
       "styles": {
         "display": "block",
@@ -1587,10 +1587,10 @@
         "tag-suggestion-group-undefined"
       ],
       "rect": {
-        "x": 506,
+        "x": 501,
         "y": 562,
-        "width": 429,
-        "height": 114
+        "width": 437,
+        "height": 116
       },
       "styles": {
         "display": "block",
@@ -1629,9 +1629,9 @@
       ],
       "text": "SUGGESTED NEXT",
       "rect": {
-        "x": 506,
+        "x": 501,
         "y": 562,
-        "width": 429,
+        "width": 437,
         "height": 27
       },
       "styles": {
@@ -1670,10 +1670,10 @@
         "tag-suggestion-group-list"
       ],
       "rect": {
-        "x": 506,
-        "y": 589,
-        "width": 429,
-        "height": 87
+        "x": 501,
+        "y": 590,
+        "width": 437,
+        "height": 89
       },
       "styles": {
         "display": "block",
@@ -1712,10 +1712,10 @@
         "tag-suggestion"
       ],
       "rect": {
-        "x": 506,
-        "y": 589,
-        "width": 429,
-        "height": 42
+        "x": 501,
+        "y": 590,
+        "width": 437,
+        "height": 43
       },
       "styles": {
         "display": "flex",
@@ -1753,9 +1753,9 @@
         "tag-suggestion-main"
       ],
       "rect": {
-        "x": 518,
-        "y": 600,
-        "width": 389,
+        "x": 514,
+        "y": 601,
+        "width": 396,
         "height": 21
       },
       "styles": {
@@ -1795,9 +1795,9 @@
       ],
       "text": "campfire",
       "rect": {
-        "x": 518,
-        "y": 600,
-        "width": 389,
+        "x": 514,
+        "y": 601,
+        "width": 396,
         "height": 21
       },
       "styles": {
@@ -1836,8 +1836,8 @@
         "tag-suggestion-side"
       ],
       "rect": {
-        "x": 915,
-        "y": 600,
+        "x": 919,
+        "y": 601,
         "width": 7,
         "height": 18
       },
@@ -1878,8 +1878,8 @@
       ],
       "text": "6",
       "rect": {
-        "x": 915,
-        "y": 600,
+        "x": 919,
+        "y": 601,
         "width": 7,
         "height": 18
       },
@@ -1920,10 +1920,10 @@
         "tag-suggestion"
       ],
       "rect": {
-        "x": 506,
-        "y": 635,
-        "width": 429,
-        "height": 41
+        "x": 501,
+        "y": 637,
+        "width": 437,
+        "height": 42
       },
       "styles": {
         "display": "flex",
@@ -1961,9 +1961,9 @@
         "tag-suggestion-main"
       ],
       "rect": {
-        "x": 518,
-        "y": 646,
-        "width": 389,
+        "x": 514,
+        "y": 648,
+        "width": 396,
         "height": 21
       },
       "styles": {
@@ -2003,9 +2003,9 @@
       ],
       "text": "night-hike",
       "rect": {
-        "x": 518,
-        "y": 646,
-        "width": 389,
+        "x": 514,
+        "y": 648,
+        "width": 396,
         "height": 21
       },
       "styles": {
@@ -2044,8 +2044,8 @@
         "tag-suggestion-side"
       ],
       "rect": {
-        "x": 915,
-        "y": 646,
+        "x": 919,
+        "y": 648,
         "width": 7,
         "height": 18
       },
@@ -2086,8 +2086,8 @@
       ],
       "text": "4",
       "rect": {
-        "x": 915,
-        "y": 646,
+        "x": 919,
+        "y": 648,
         "width": 7,
         "height": 18
       },
@@ -2128,10 +2128,10 @@
         "tag-suggestion-group-undefined"
       ],
       "rect": {
-        "x": 506,
-        "y": 684,
-        "width": 429,
-        "height": 68
+        "x": 501,
+        "y": 686,
+        "width": 437,
+        "height": 69
       },
       "styles": {
         "display": "block",
@@ -2170,9 +2170,9 @@
       ],
       "text": "RECENT TAGS",
       "rect": {
-        "x": 506,
-        "y": 684,
-        "width": 429,
+        "x": 501,
+        "y": 686,
+        "width": 437,
         "height": 27
       },
       "styles": {
@@ -2211,10 +2211,10 @@
         "tag-suggestion-group-list"
       ],
       "rect": {
-        "x": 506,
-        "y": 711,
-        "width": 429,
-        "height": 41
+        "x": 501,
+        "y": 714,
+        "width": 437,
+        "height": 42
       },
       "styles": {
         "display": "block",
@@ -2253,10 +2253,10 @@
         "tag-suggestion"
       ],
       "rect": {
-        "x": 506,
-        "y": 711,
-        "width": 429,
-        "height": 41
+        "x": 501,
+        "y": 714,
+        "width": 437,
+        "height": 42
       },
       "styles": {
         "display": "flex",
@@ -2294,9 +2294,9 @@
         "tag-suggestion-main"
       ],
       "rect": {
-        "x": 518,
-        "y": 721,
-        "width": 389,
+        "x": 514,
+        "y": 725,
+        "width": 396,
         "height": 21
       },
       "styles": {
@@ -2336,9 +2336,9 @@
       ],
       "text": "journal",
       "rect": {
-        "x": 518,
-        "y": 721,
-        "width": 389,
+        "x": 514,
+        "y": 725,
+        "width": 396,
         "height": 21
       },
       "styles": {
@@ -2377,8 +2377,8 @@
         "tag-suggestion-side"
       ],
       "rect": {
-        "x": 915,
-        "y": 721,
+        "x": 919,
+        "y": 725,
         "width": 7,
         "height": 18
       },
@@ -2419,8 +2419,8 @@
       ],
       "text": "3",
       "rect": {
-        "x": 915,
-        "y": 721,
+        "x": 919,
+        "y": 725,
         "width": 7,
         "height": 18
       },

--- a/static/e2e/specs/performance/tag-modal-performance.spec.js
+++ b/static/e2e/specs/performance/tag-modal-performance.spec.js
@@ -1,0 +1,461 @@
+import { test, expect } from '../../fixtures/index.js';
+
+const BASELINE_ITEM_COUNT = 120;
+const BASELINE_TARGET_INDEX = 80;
+const DEEP_ITEM_COUNT = 4000;
+const DEEP_TARGET_INDEX = 3200;
+const SELECTION_SIZE = 3;
+const DEGRADATION_FACTOR = 4;
+const DURATION_RATIO_FLOOR_MS = 0.25;
+const SUGGESTION_RATIO_FLOOR_MS = 16;
+const NEW_BULK_TAG = 'perf-bulk-added-tag';
+const SUGGESTION_QUERY = 'sug';
+const COARSE_POINTER_PROJECTS = new Set([
+    'mobile-chrome',
+    'mobile-safari',
+    'tablet',
+    'android-firefox',
+]);
+const THUMBNAIL_PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0KkAAAAASUVORK5CYII=';
+const CATALOG_TAGS = [
+    'common-tag',
+    'seed-tag',
+    'focus-tag',
+    'suggested-alpha',
+    'suggested-beta',
+    'suggested-gamma',
+    NEW_BULK_TAG,
+];
+const RELATED_SUGGESTIONS = [
+    { name: 'suggested-alpha', itemCount: 8, relatedCount: 4 },
+    { name: 'suggested-beta', itemCount: 6, relatedCount: 3 },
+    { name: 'suggested-gamma', itemCount: 5, relatedCount: 2 },
+];
+
+function syntheticPath(scenarioId, index) {
+    return `/__perf__/${scenarioId}/item-${index}.jpg`;
+}
+
+function createSyntheticApiState() {
+    return {
+        catalogTags: [...CATALOG_TAGS],
+        relatedSuggestions: [...RELATED_SUGGESTIONS],
+        tagsByPath: new Map(),
+    };
+}
+
+function parseRouteJson(route) {
+    const payload = route.request().postData();
+    return payload ? JSON.parse(payload) : {};
+}
+
+function buildScenario(id, totalItems, targetIndex) {
+    return {
+        id,
+        totalItems,
+        targetIndex,
+        selectionIndices: Array.from(
+            { length: SELECTION_SIZE },
+            (_, offset) => targetIndex + offset
+        ),
+    };
+}
+
+function primeScenarioTagState(apiState, scenario) {
+    apiState.catalogTags = [...CATALOG_TAGS];
+    apiState.relatedSuggestions = [...RELATED_SUGGESTIONS];
+    apiState.tagsByPath = new Map();
+
+    for (const [offset, index] of scenario.selectionIndices.entries()) {
+        const tags = ['common-tag'];
+        if (offset < 2) {
+            tags.push('seed-tag');
+        }
+        if (offset === 0) {
+            tags.push('focus-tag');
+        }
+        apiState.tagsByPath.set(syntheticPath(scenario.id, index), tags);
+    }
+}
+
+async function getSeedMediaItem(page) {
+    const response = await page.request.get('/api/media?path=&sort=name&order=asc');
+    expect(response.ok(), 'loading root media for synthetic perf seed should succeed').toBe(true);
+
+    const payload = await response.json();
+    const items = payload?.items || [];
+    const item = items.find((entry) => entry?.type === 'image' || entry?.type === 'video');
+
+    expect(
+        item,
+        'expected at least one media item for synthetic performance fixtures'
+    ).toBeTruthy();
+    return item;
+}
+
+async function installSyntheticTagApiMocks(page, apiState) {
+    await page.route(/\/api\/thumbnails\/.*__perf__\//, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'image/png',
+            body: Buffer.from(THUMBNAIL_PNG_BASE64, 'base64'),
+        });
+    });
+
+    await page.route(/\/api\/tags(?:\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') {
+            await route.fallback();
+            return;
+        }
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(
+                apiState.catalogTags.map((name, index) => ({
+                    name,
+                    itemCount: Math.max(1, apiState.catalogTags.length - index),
+                }))
+            ),
+        });
+    });
+
+    await page.route('**/api/tags/query', async (route) => {
+        const { paths = [] } = parseRouteJson(route);
+        const isSyntheticRequest =
+            Array.isArray(paths) && paths.every((path) => path.includes('/__perf__/'));
+        if (!isSyntheticRequest) {
+            await route.fallback();
+            return;
+        }
+
+        const payload = {};
+        for (const path of paths) {
+            payload[path] = [...(apiState.tagsByPath.get(path) || [])];
+        }
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(payload),
+        });
+    });
+
+    await page.route('**/api/tags/suggestions', async (route) => {
+        const { exclude = [] } = parseRouteJson(route);
+        const excluded = new Set(exclude);
+        const suggestions = apiState.relatedSuggestions.filter((tag) => !excluded.has(tag.name));
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(suggestions),
+        });
+    });
+
+    await page.route('**/api/tags/bulk', async (route) => {
+        const request = route.request();
+        const { paths = [], tag } = parseRouteJson(route);
+        const isSyntheticRequest =
+            Array.isArray(paths) && paths.every((path) => path.includes('/__perf__/'));
+        if (!isSyntheticRequest) {
+            await route.fallback();
+            return;
+        }
+
+        const tagsByPath = {};
+        for (const path of paths) {
+            const nextTags = new Set(apiState.tagsByPath.get(path) || []);
+            if (request.method() === 'POST' && tag) {
+                nextTags.add(tag);
+            }
+            if (request.method() === 'DELETE' && tag) {
+                nextTags.delete(tag);
+            }
+
+            const finalized = [...nextTags].sort();
+            apiState.tagsByPath.set(path, finalized);
+            tagsByPath[path] = finalized;
+        }
+
+        if (request.method() === 'POST' && tag && !apiState.catalogTags.includes(tag)) {
+            apiState.catalogTags = [...apiState.catalogTags, tag];
+        }
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                success: paths.length,
+                tagsByPath,
+            }),
+        });
+    });
+}
+
+async function prepareSyntheticGallery(page, seedItem, scenario) {
+    return page.evaluate(
+        async ({ item, scenarioConfig }) => {
+            const waitFrames = async (count = 2) => {
+                for (let index = 0; index < count; index++) {
+                    await new Promise((resolve) => requestAnimationFrame(resolve));
+                }
+            };
+
+            const syntheticItems = Array.from(
+                { length: scenarioConfig.totalItems },
+                (_, index) => ({
+                    ...item,
+                    path: `/__perf__/${scenarioConfig.id}/item-${index}.jpg`,
+                    name: `${scenarioConfig.id}-item-${index}.jpg`,
+                    isFavorite: false,
+                    tags: [],
+                })
+            );
+
+            if (
+                typeof Tags !== 'undefined' &&
+                !Tags.elements?.tagModal?.classList.contains('hidden')
+            ) {
+                Tags.closeModal();
+            }
+            if (typeof ItemSelection !== 'undefined' && ItemSelection.isActive) {
+                ItemSelection.exitSelectionMode();
+            }
+
+            InfiniteScroll.resetState();
+            MediaApp.state.mediaFiles = syntheticItems;
+            InfiniteScroll.state.totalItems = syntheticItems.length;
+            InfiniteScroll.state.loadedItems = syntheticItems;
+            InfiniteScroll.state.hasMore = false;
+            InfiniteScroll.state.currentPage = Math.ceil(
+                syntheticItems.length / InfiniteScroll.config.batchSize
+            );
+
+            InfiniteScroll.renderItems(syntheticItems, false);
+            InfiniteScroll.updateStats();
+            InfiniteScroll.updateVirtualSpacer();
+            InfiniteScroll.updateScrollScrubber();
+            window.scrollTo({ top: 0, behavior: 'instant' });
+            await waitFrames(2);
+
+            InfiniteScroll._scrollToLoadedItem(scenarioConfig.targetIndex + 1);
+            InfiniteScroll.scheduleRenderWindowUpdate(true);
+            await waitFrames(3);
+
+            const mountedItems = document.querySelectorAll(
+                '#gallery .gallery-item:not(.skeleton)'
+            ).length;
+            const selectionPaths = scenarioConfig.selectionIndices.map(
+                (index) => syntheticItems[index].path
+            );
+
+            return {
+                totalItems: syntheticItems.length,
+                mountedItems,
+                windowed: mountedItems < syntheticItems.length,
+                selectionPaths,
+            };
+        },
+        { item: seedItem, scenarioConfig: scenario }
+    );
+}
+
+async function measureBulkTagModalFlow(page, scenario) {
+    return page.evaluate(
+        async ({ scenarioConfig, newTag, suggestionQuery }) => {
+            const waitFrames = async (count = 2) => {
+                for (let index = 0; index < count; index++) {
+                    await new Promise((resolve) => requestAnimationFrame(resolve));
+                }
+            };
+
+            const waitUntil = async (predicate, timeoutMs = 5000) => {
+                const startedAt = performance.now();
+                while (performance.now() - startedAt < timeoutMs) {
+                    if (predicate()) {
+                        return;
+                    }
+                    await waitFrames(1);
+                }
+                throw new Error('Timed out waiting for tag modal state');
+            };
+
+            const selectionPaths = scenarioConfig.selectionIndices.map(
+                (index) => `/__perf__/${scenarioConfig.id}/item-${index}.jpg`
+            );
+
+            if (typeof Tags === 'undefined' || typeof ItemSelection === 'undefined') {
+                throw new Error('Tags or ItemSelection module is not available');
+            }
+
+            await Tags.loadAllTags();
+            await waitFrames(2);
+
+            const elements = selectionPaths.map((path) => {
+                const element =
+                    InfiniteScroll._galleryItemsByPath?.get(path) ||
+                    document.querySelector(`.gallery-item[data-path="${CSS.escape(path)}"]`);
+                if (!element) {
+                    throw new Error(`Expected mounted gallery item for ${path}`);
+                }
+                return element;
+            });
+
+            if (ItemSelection.isActive) {
+                ItemSelection.exitSelectionMode();
+                await waitFrames(2);
+            }
+
+            ItemSelection.enterSelectionMode(elements[0]);
+            for (const element of elements.slice(1)) {
+                ItemSelection.toggleItem(element);
+            }
+            ItemSelection.updateToolbar();
+            ItemSelection.elements?.toolbar?.classList.remove('hidden');
+
+            const openStartedAt = performance.now();
+            ItemSelection.openBulkTagModal();
+            await waitUntil(() => {
+                return (
+                    !Tags.elements.tagModal.classList.contains('hidden') &&
+                    Tags.elements.currentTags.querySelectorAll('.tag-chip').length > 0
+                );
+            });
+            await waitFrames(2);
+            const openDuration = performance.now() - openStartedAt;
+
+            Tags.elements.tagInput.value = suggestionQuery;
+            const suggestionStartedAt = performance.now();
+            Tags.showSuggestions(suggestionQuery);
+            await waitFrames(1);
+            const suggestionDuration = performance.now() - suggestionStartedAt;
+
+            const suggestionCount =
+                Tags.elements.tagSuggestions.querySelectorAll('.tag-suggestion').length;
+
+            Tags.elements.tagInput.value = newTag;
+            const addStartedAt = performance.now();
+            await Tags.addTagFromInput();
+            await waitFrames(2);
+            const addDuration = performance.now() - addStartedAt;
+
+            const currentTagCount = Tags.elements.currentTags.querySelectorAll('.tag-chip').length;
+            const mountedItems = document.querySelectorAll(
+                '#gallery .gallery-item:not(.skeleton)'
+            ).length;
+            const selectedCount = ItemSelection.selectedPaths.size;
+            const addedToAll = selectionPaths.every((path) => {
+                const currentTag = Tags.tagSources?.get(newTag);
+                return Array.isArray(currentTag)
+                    ? currentTag.length === selectionPaths.length
+                    : false;
+            });
+
+            Tags.closeModal();
+            ItemSelection.exitSelectionMode();
+
+            return {
+                openDuration,
+                suggestionDuration,
+                addDuration,
+                suggestionCount,
+                currentTagCount,
+                mountedItems,
+                selectedCount,
+                addedToAll,
+            };
+        },
+        {
+            scenarioConfig: scenario,
+            newTag: NEW_BULK_TAG,
+            suggestionQuery: SUGGESTION_QUERY,
+        }
+    );
+}
+
+function safeRatio(numerator, denominator, floorMs = DURATION_RATIO_FLOOR_MS) {
+    return numerator / Math.max(denominator, floorMs);
+}
+
+test.describe('Tag Modal Performance @tags @performance @slow', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test('bulk tag modal remains responsive deep in a large loaded gallery', async ({
+        page,
+        loginHelpers,
+    }, testInfo) => {
+        test.skip(
+            COARSE_POINTER_PROJECTS.has(testInfo.project.name),
+            'Loaded-item windowing is intentionally disabled on coarse-pointer projects; this regression is covered by fine-pointer browsers only'
+        );
+
+        await loginHelpers.login(page);
+
+        const apiState = createSyntheticApiState();
+        await installSyntheticTagApiMocks(page, apiState);
+
+        const seedItem = await getSeedMediaItem(page);
+        const baselineScenario = buildScenario(
+            'baseline',
+            BASELINE_ITEM_COUNT,
+            BASELINE_TARGET_INDEX
+        );
+        const deepScenario = buildScenario('deep', DEEP_ITEM_COUNT, DEEP_TARGET_INDEX);
+
+        primeScenarioTagState(apiState, baselineScenario);
+        const baselineGallery = await prepareSyntheticGallery(page, seedItem, baselineScenario);
+        const baselineMetrics = await measureBulkTagModalFlow(page, baselineScenario);
+
+        primeScenarioTagState(apiState, deepScenario);
+        const deepGallery = await prepareSyntheticGallery(page, seedItem, deepScenario);
+        const deepMetrics = await measureBulkTagModalFlow(page, deepScenario);
+
+        console.log('Tag modal performance baseline:', {
+            gallery: baselineGallery,
+            metrics: baselineMetrics,
+        });
+        console.log('Tag modal performance deep gallery:', {
+            gallery: deepGallery,
+            metrics: deepMetrics,
+        });
+
+        expect(baselineGallery.windowed).toBe(false);
+        expect(deepGallery.windowed).toBe(true);
+        expect(deepGallery.mountedItems).toBeLessThan(deepGallery.totalItems);
+        expect(baselineMetrics.selectedCount).toBe(SELECTION_SIZE);
+        expect(deepMetrics.selectedCount).toBe(SELECTION_SIZE);
+        expect(baselineMetrics.suggestionCount).toBeGreaterThan(0);
+        expect(deepMetrics.suggestionCount).toBeGreaterThan(0);
+        expect(deepMetrics.currentTagCount).toBeGreaterThan(0);
+        expect(deepMetrics.addedToAll).toBe(true);
+
+        const openRatio = safeRatio(deepMetrics.openDuration, baselineMetrics.openDuration);
+        const suggestionRatio = safeRatio(
+            deepMetrics.suggestionDuration,
+            baselineMetrics.suggestionDuration,
+            SUGGESTION_RATIO_FLOOR_MS
+        );
+        const addRatio = safeRatio(deepMetrics.addDuration, baselineMetrics.addDuration);
+
+        console.log('Tag modal performance ratios:', {
+            openRatio,
+            suggestionRatio,
+            addRatio,
+        });
+
+        expect(
+            openRatio,
+            `deep-gallery modal open degraded ${openRatio.toFixed(2)}x versus baseline`
+        ).toBeLessThan(DEGRADATION_FACTOR);
+        expect(
+            suggestionRatio,
+            `deep-gallery suggestion render degraded ${suggestionRatio.toFixed(2)}x versus baseline`
+        ).toBeLessThan(DEGRADATION_FACTOR);
+        expect(
+            addRatio,
+            `deep-gallery bulk add degraded ${addRatio.toFixed(2)}x versus baseline`
+        ).toBeLessThan(DEGRADATION_FACTOR);
+    });
+});

--- a/static/js/infinite-scroll.js
+++ b/static/js/infinite-scroll.js
@@ -27,6 +27,7 @@ const InfiniteScroll = {
         rootMargin: '1200px',
         skeletonCount: 12,
         renderOverscanRows: 6,
+        renderWindowMinItems: 1200,
     },
 
     // ── State ────────────────────────────────────────────────────────────────
@@ -55,6 +56,7 @@ const InfiniteScroll = {
     _restorePopoverTimer: null, // auto-dismiss timer for restore popover
     _restorePopoverHideTimer: null, // 250 ms fade-out delay timer (tracked so it can be cancelled)
     _saveScrollTimer: null, // debounce timer for persistent position save
+    _resumeLoadMoreFromOffset: false, // continue loading from exact offset after mid-page catch-up
     // Set to true while the gallery is showing a static collection view.
     // Prevents saveToCache() from persisting collection items as directory cache.
     _isCollectionView: false,
@@ -298,6 +300,7 @@ const InfiniteScroll = {
         this.state.currentPage = cached.currentPage;
         this.state.hasMore = mergedItems.length < initialData.totalItems;
         this.state.loadedItems = mergedItems;
+        this._resumeLoadMoreFromOffset = cached.resumeLoadMoreFromOffset === true;
         this.renderItems(mergedItems, false);
 
         if (savedScrollPosition !== null) {
@@ -323,6 +326,7 @@ const InfiniteScroll = {
         this._catchUpTarget = 0;
         this._isScrubbing = false;
         this._scrubFraction = 0;
+        this._resumeLoadMoreFromOffset = false;
         this._cachedGridGeometry = null;
         this._renderWindowStart = 0;
         this._renderWindowEnd = 0;
@@ -489,10 +493,35 @@ const InfiniteScroll = {
         grid.style.top = `${offsetIntoSpacer}px`;
     },
 
-    _getRenderWindowRange() {
+    _hasCoarsePointer() {
+        if (typeof window.matchMedia === 'function') {
+            try {
+                if (window.matchMedia('(pointer: coarse)').matches) {
+                    return true;
+                }
+            } catch {
+                // Ignore unsupported media queries and fall through.
+            }
+        }
+
+        return navigator.maxTouchPoints > 0;
+    },
+
+    _shouldWindowLoadedItems() {
+        return (
+            this.state.loadedItems.length >= this.config.renderWindowMinItems &&
+            !this._hasCoarsePointer()
+        );
+    },
+
+    _getRenderWindowRange(force = false) {
         const loadedCount = this.state.loadedItems.length;
         if (loadedCount === 0) {
             return { startIndex: 0, endIndex: 0 };
+        }
+
+        if (!this._shouldWindowLoadedItems()) {
+            return { startIndex: 0, endIndex: loadedCount };
         }
 
         const { cols, rowHeight } = this._getGridGeometry();
@@ -503,6 +532,24 @@ const InfiniteScroll = {
         const galleryTop = this.elements.gallery.getBoundingClientRect().top + window.scrollY;
         const scrollOffset = Math.max(0, window.scrollY - galleryTop);
         const firstVisibleRow = Math.max(0, Math.floor(scrollOffset / safeRowHeight));
+
+        if (!force && this._renderWindowEnd > this._renderWindowStart) {
+            const currentStartRow = Math.floor(this._renderWindowStart / safeCols);
+            const currentEndRow = Math.ceil(this._renderWindowEnd / safeCols);
+            const hysteresisRows = Math.max(1, Math.floor(overscanRows / 2));
+            const visibleEndRow = firstVisibleRow + viewportRows;
+
+            if (
+                firstVisibleRow >= currentStartRow + hysteresisRows &&
+                visibleEndRow <= currentEndRow - hysteresisRows
+            ) {
+                return {
+                    startIndex: this._renderWindowStart,
+                    endIndex: this._renderWindowEnd,
+                };
+            }
+        }
+
         const startRow = Math.max(0, firstVisibleRow - overscanRows);
         const endRow = firstVisibleRow + viewportRows + overscanRows;
 
@@ -526,7 +573,7 @@ const InfiniteScroll = {
             return;
         }
 
-        const { startIndex, endIndex } = this._getRenderWindowRange();
+        const { startIndex, endIndex } = this._getRenderWindowRange(force);
         if (
             !force &&
             startIndex === this._renderWindowStart &&
@@ -614,6 +661,16 @@ const InfiniteScroll = {
         window.scrollTo({ top, behavior: 'instant' });
     },
 
+    _jumpToLoadedItem(itemNumber, { refillViewport = false } = {}) {
+        this._scrollToLoadedItem(itemNumber);
+        // Programmatic jumps cannot rely on the browser delivering a scroll
+        // event soon enough to remount the correct slice, especially in Firefox.
+        this.scheduleRenderWindowUpdate(true);
+        if (refillViewport) {
+            this.checkAndFillViewport();
+        }
+    },
+
     // ─────────────────────────────────────────────────────────────────────────
     // Custom scrubber
     // ─────────────────────────────────────────────────────────────────────────
@@ -695,8 +752,7 @@ const InfiniteScroll = {
         if (targetItem <= loaded) {
             // Fraction 0 / item 1 → absolute top of the page so the header and
             // favorites bar are fully visible, not just the first gallery row.
-            this._scrollToLoadedItem(targetItem);
-            this.checkAndFillViewport();
+            this._jumpToLoadedItem(targetItem, { refillViewport: true });
             return;
         }
 
@@ -745,8 +801,9 @@ const InfiniteScroll = {
             }
             if (!res.ok) return null;
             return await res.json();
-        } catch {
+        } catch (err) {
             clearTimeout(tid);
+            if (err.name === 'AbortError' || err instanceof TypeError) throw err;
             return null;
         }
     },
@@ -810,10 +867,13 @@ const InfiniteScroll = {
                 this.state.loadedItems.push(...data.items);
                 this.state.totalItems = data.totalItems;
                 this.state.hasMore = this.state.loadedItems.length < data.totalItems;
-                // Align currentPage so sequential loadMore resumes from the right page
-                this.state.currentPage = Math.ceil(
-                    this.state.loadedItems.length / this.config.batchSize
+                this.state.currentPage = Math.max(
+                    1,
+                    Math.ceil(this.state.loadedItems.length / this.config.batchSize)
                 );
+                this._resumeLoadMoreFromOffset =
+                    this.state.hasMore &&
+                    this.state.loadedItems.length % this.config.batchSize !== 0;
                 this.renderItems(data.items, true);
             } else {
                 this.state.loadFailed = true;
@@ -831,7 +891,7 @@ const InfiniteScroll = {
                 this.updateVirtualSpacer();
 
                 if (!this.state.loadFailed) {
-                    this._scrollToLoadedItem(this._catchUpTarget);
+                    this._jumpToLoadedItem(this._catchUpTarget);
                 }
 
                 document.documentElement.classList.remove('catchup-active');
@@ -865,12 +925,23 @@ const InfiniteScroll = {
         this.showSkeletons();
 
         try {
-            const data = await this._fetchPage(this.state.currentPage + 1);
+            const data = this._resumeLoadMoreFromOffset
+                ? await this._fetchOffset(this.state.loadedItems.length, this.config.batchSize)
+                : await this._fetchPage(this.state.currentPage + 1);
             if (!data) throw new Error('Failed to load more items');
 
-            this.state.currentPage++;
             this.state.loadedItems.push(...data.items);
             this.state.hasMore = this.state.loadedItems.length < this.state.totalItems;
+            if (this._resumeLoadMoreFromOffset) {
+                this.state.currentPage = Math.max(
+                    this.state.currentPage,
+                    Math.ceil(this.state.loadedItems.length / this.config.batchSize)
+                );
+            } else {
+                this.state.currentPage++;
+            }
+            this._resumeLoadMoreFromOffset =
+                this.state.hasMore && this.state.loadedItems.length % this.config.batchSize !== 0;
             this.state.loadFailed = false;
             this.renderItems(data.items, true);
         } catch (error) {
@@ -1082,6 +1153,7 @@ const InfiniteScroll = {
         this.cache.set(path, {
             loadedItems: [...this.state.loadedItems],
             currentPage: this.state.currentPage,
+            resumeLoadMoreFromOffset: this._resumeLoadMoreFromOffset,
             totalItems: this.state.totalItems,
             hasMore: this.state.hasMore,
             scrollPosition: window.scrollY,

--- a/static/tests/integration/infinite-scroll.test.js
+++ b/static/tests/integration/infinite-scroll.test.js
@@ -818,6 +818,33 @@ describe('InfiniteScroll Integration', () => {
     });
 
     describe('Loaded Item Windowing', () => {
+        it('does not window medium galleries by default', async () => {
+            Object.defineProperty(window, 'innerHeight', { value: 600, configurable: true });
+            InfiniteScroll.elements.gallery.getBoundingClientRect = () => ({ top: 0 });
+            vi.spyOn(InfiniteScroll, '_getGridGeometry').mockReturnValue({
+                cols: 4,
+                gap: 0,
+                itemSize: 100,
+                rowHeight: 100,
+            });
+
+            const initialData = {
+                items: Array.from({ length: 200 }, (_, i) => ({
+                    name: `file${i}.jpg`,
+                    path: `/test/file${i}.jpg`,
+                    type: 'image',
+                    exists: true,
+                })),
+                totalItems: 200,
+            };
+
+            await InfiniteScroll.startForDirectory('/test', initialData);
+
+            const galleryItems = document.querySelectorAll('.gallery-item:not(.skeleton)');
+            expect(galleryItems.length).toBe(200);
+            expect(InfiniteScroll.elements.gallery.style.paddingBottom).toBe('0px');
+        });
+
         it('should keep the mounted gallery slice smaller than loadedItems', async () => {
             Object.defineProperty(window, 'innerHeight', { value: 600, configurable: true });
             InfiniteScroll.elements.gallery.getBoundingClientRect = () => ({ top: 0 });
@@ -837,6 +864,8 @@ describe('InfiniteScroll Integration', () => {
                 })),
                 totalItems: 200,
             };
+
+            InfiniteScroll.config.renderWindowMinItems = 1;
 
             await InfiniteScroll.startForDirectory('/test', initialData);
 

--- a/static/tests/unit/infinite-scroll.test.js
+++ b/static/tests/unit/infinite-scroll.test.js
@@ -205,6 +205,33 @@ describe('InfiniteScroll Module', () => {
         });
     });
 
+    describe('_shouldWindowLoadedItems()', () => {
+        test('returns false below the minimum item threshold', () => {
+            InfiniteScroll.state.loadedItems = Array.from({ length: 200 }, (_, i) => ({
+                path: `/img${i}.jpg`,
+            }));
+
+            expect(InfiniteScroll._shouldWindowLoadedItems()).toBe(false);
+        });
+
+        test('returns false on coarse-pointer devices', () => {
+            InfiniteScroll.state.loadedItems = Array.from({ length: 5000 }, (_, i) => ({
+                path: `/img${i}.jpg`,
+            }));
+            Object.defineProperty(window, 'matchMedia', {
+                configurable: true,
+                value: vi.fn((query) => ({
+                    matches: query === '(pointer: coarse)',
+                    media: query,
+                    addEventListener: vi.fn(),
+                    removeEventListener: vi.fn(),
+                })),
+            });
+
+            expect(InfiniteScroll._shouldWindowLoadedItems()).toBe(false);
+        });
+    });
+
     describe('Cache operations - saveToCache()', () => {
         test('saves state to cache', () => {
             InfiniteScroll.state.loadedItems = [
@@ -372,6 +399,38 @@ describe('InfiniteScroll Module', () => {
             InfiniteScroll._scrollToLoadedItem(101);
 
             expect(scrollSpy).toHaveBeenCalledWith({ top: 7692, behavior: 'instant' });
+        });
+    });
+
+    describe('_jumpToLoadedItem()', () => {
+        test('forces a render-window update after scrolling to a loaded item', () => {
+            const scrollSpy = vi
+                .spyOn(InfiniteScroll, '_scrollToLoadedItem')
+                .mockImplementation(() => {});
+            const renderSpy = vi
+                .spyOn(InfiniteScroll, 'scheduleRenderWindowUpdate')
+                .mockImplementation(() => {});
+            const fillSpy = vi
+                .spyOn(InfiniteScroll, 'checkAndFillViewport')
+                .mockImplementation(() => {});
+
+            InfiniteScroll._jumpToLoadedItem(125);
+
+            expect(scrollSpy).toHaveBeenCalledWith(125);
+            expect(renderSpy).toHaveBeenCalledWith(true);
+            expect(fillSpy).not.toHaveBeenCalled();
+        });
+
+        test('optionally refills the viewport after a jump', () => {
+            vi.spyOn(InfiniteScroll, '_scrollToLoadedItem').mockImplementation(() => {});
+            vi.spyOn(InfiniteScroll, 'scheduleRenderWindowUpdate').mockImplementation(() => {});
+            const fillSpy = vi
+                .spyOn(InfiniteScroll, 'checkAndFillViewport')
+                .mockImplementation(() => {});
+
+            InfiniteScroll._jumpToLoadedItem(125, { refillViewport: true });
+
+            expect(fillSpy).toHaveBeenCalled();
         });
     });
 
@@ -1417,8 +1476,12 @@ describe('InfiniteScroll Module', () => {
             const fillSpy = vi
                 .spyOn(InfiniteScroll, 'checkAndFillViewport')
                 .mockImplementation(() => {});
+            const jumpSpy = vi
+                .spyOn(InfiniteScroll, 'scheduleRenderWindowUpdate')
+                .mockImplementation(() => {});
             InfiniteScroll._onScrubberRelease();
             expect(fillSpy).toHaveBeenCalled();
+            expect(jumpSpy).toHaveBeenCalledWith(true);
         });
 
         test('schedules _parallelCatchUp when target item is far ahead of loaded count', () => {
@@ -1439,6 +1502,46 @@ describe('InfiniteScroll Module', () => {
             vi.spyOn(InfiniteScroll, '_parallelCatchUp').mockResolvedValue(undefined);
             InfiniteScroll._onScrubberRelease();
             expect(clearSpy).toHaveBeenCalledWith(999);
+        });
+    });
+
+    describe('loadMore()', () => {
+        test('continues with offset fetches when catch-up stops mid-page', async () => {
+            InfiniteScroll.state.isLoading = false;
+            InfiniteScroll.state.hasMore = true;
+            InfiniteScroll.state.totalItems = 299;
+            InfiniteScroll.state.currentPage = 3;
+            InfiniteScroll.state.loadedItems = Array.from({ length: 235 }, (_, i) => ({
+                path: `/img${i}.jpg`,
+            }));
+            InfiniteScroll._resumeLoadMoreFromOffset = true;
+            InfiniteScroll.config.batchSize = 100;
+
+            const offsetItems = Array.from({ length: 64 }, (_, i) => ({
+                path: `/img${235 + i}.jpg`,
+            }));
+
+            const fetchOffsetSpy = vi.spyOn(InfiniteScroll, '_fetchOffset').mockResolvedValue({
+                items: offsetItems,
+                totalItems: 299,
+            });
+            const fetchPageSpy = vi.spyOn(InfiniteScroll, '_fetchPage').mockResolvedValue(null);
+
+            vi.spyOn(InfiniteScroll, 'showSkeletons').mockImplementation(() => {});
+            vi.spyOn(InfiniteScroll, 'hideSkeletons').mockImplementation(() => {});
+            vi.spyOn(InfiniteScroll, 'updateLoadMoreVisibility').mockImplementation(() => {});
+            vi.spyOn(InfiniteScroll, 'updateStats').mockImplementation(() => {});
+            vi.spyOn(InfiniteScroll, 'updateVirtualSpacer').mockImplementation(() => {});
+            vi.spyOn(InfiniteScroll, 'updateScrollScrubber').mockImplementation(() => {});
+            vi.spyOn(InfiniteScroll, 'renderItems').mockImplementation(() => {});
+
+            await InfiniteScroll.loadMore();
+
+            expect(fetchOffsetSpy).toHaveBeenCalledWith(235, 100);
+            expect(fetchPageSpy).not.toHaveBeenCalled();
+            expect(InfiniteScroll.state.loadedItems).toHaveLength(299);
+            expect(InfiniteScroll.state.hasMore).toBe(false);
+            expect(InfiniteScroll.state.currentPage).toBe(3);
         });
     });
 


### PR DESCRIPTION
Fixes #542

## Description

After v0.18.1, visual regressions abound. See changelog for details on what's fixed.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [X] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [X] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags / AutoTagger
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [x] I have run `make pr-check` and all relevant checks passed
    - Backend changes: `make lint`, `make test`, and `make test-race`
    - Frontend changes: `make frontend-check`, `make frontend-test-unit`, `make frontend-test-integration-auto`, and `make frontend-test-e2e-smoke-auto`
- [ ] If I needed Go lint autofixes before rerunning checks, I used `make pr-check-fix`

### Frontend PR Checks

- [x] If this PR changes frontend flows outside the smoke subset, I also ran broader or focused browser coverage such as `make frontend-test-e2e`, `make frontend-test-e2e-file <spec>`, or `make frontend-test-e2e-module <tag>`
- [ ] If this PR intentionally changes UI presentation, I ran `make frontend-test-e2e-visual`
- [ ] If this PR intentionally changes committed visual baselines, I ran `make frontend-test-e2e-visual-baselines` and included the updated artifacts
- [ ] If this PR refreshes documentation imagery, I ran `make frontend-test-e2e-docs-screenshots` and included the updated `docs/images/` assets
- [ ] If this PR affects performance-sensitive frontend flows, I ran the relevant `make frontend-test-e2e-performance*` lane

## Related Issues

<!-- Link related issues here -->

Closes #542 
Related to #

## Additional Notes

<!-- Any additional information -->
