### PR TITLE
fix(ui): passkeys flow doesn't try to auto-start when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - build(deps): bump node from 22-bookworm-slim to 26-bookworm-slim ([#569](https://github.com/djryanj/media-viewer/pull/569))
 - chore: clean up old legacy vanilla JS code ([#572](https://github.com/djryanj/media-viewer/issues/572))
+- fix(ui): passkey authorization flow will auto-trigger if available. ([#570](https://github.com/djryanj/media-viewer/issues/570))
 
 ## [0.19.0] - 06-15-2026
 

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -57,6 +57,41 @@
     // ── WebAuthn ──────────────────────────────────────────────────────────────
     let conditionalUIAbort: AbortController | null = null;
 
+    async function autoLoginWithPasskey() {
+        if (!webauthnSupported) return;
+        error = '';
+        passkeyLoading = true;
+        try {
+            const { options, sessionId } = await authApi.webauthnLoginBegin();
+            const publicKey = prepareGetOptions(options.publicKey);
+            conditionalUIAbort = new AbortController();
+            const credential = (await navigator.credentials.get({
+                publicKey,
+                signal: conditionalUIAbort.signal
+            })) as PublicKeyCredential | null;
+            if (!credential) {
+                startConditionalUI();
+                return;
+            }
+            await authApi.webauthnLoginFinish(sessionId, credential);
+            await authStore.check();
+            goto('/');
+        } catch (err) {
+            const name = (err as Error)?.name;
+            if (name === 'AbortError') return;
+            if (name !== 'NotAllowedError') {
+                if (err instanceof ApiError) {
+                    error = err.message || 'Passkey authentication failed';
+                } else {
+                    error = 'Passkey authentication failed';
+                }
+            }
+            startConditionalUI();
+        } finally {
+            passkeyLoading = false;
+        }
+    }
+
     async function loginWithPasskey() {
         if (passkeyLoading || !webauthnSupported) return;
         conditionalUIAbort?.abort();
@@ -121,7 +156,7 @@
             try {
                 const { available } = await authApi.webauthnAvailable();
                 passkeyAvailable = available;
-                if (available) startConditionalUI();
+                if (available) autoLoginWithPasskey();
             } catch {
                 /* ignore */
             }

--- a/frontend/src/tests/components/LoginPage.test.ts
+++ b/frontend/src/tests/components/LoginPage.test.ts
@@ -133,7 +133,11 @@ describe('Login page — passkey auto-trigger', () => {
         render(LoginPage);
         await waitFor(() => {
             expect(
-                (screen.getByRole('button', { name: /sign in with a passkey/i }) as HTMLButtonElement).disabled
+                (
+                    screen.getByRole('button', {
+                        name: /sign in with a passkey/i
+                    }) as HTMLButtonElement
+                ).disabled
             ).toBe(false);
         });
         expect(screen.queryByRole('alert')).toBeNull();
@@ -157,7 +161,11 @@ describe('Login page — passkey auto-trigger', () => {
         // Wait for auto-trigger to fail silently and re-enable the button
         await waitFor(() => {
             expect(
-                (screen.getByRole('button', { name: /sign in with a passkey/i }) as HTMLButtonElement).disabled
+                (
+                    screen.getByRole('button', {
+                        name: /sign in with a passkey/i
+                    }) as HTMLButtonElement
+                ).disabled
             ).toBe(false);
         });
 

--- a/frontend/src/tests/components/LoginPage.test.ts
+++ b/frontend/src/tests/components/LoginPage.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+import { goto } from '$app/navigation';
+import { ApiError } from '$lib/api/client';
+import LoginPage from '../../routes/login/+page.svelte';
+
+const mocks = vi.hoisted(() => ({
+    webauthnAvailable: vi.fn(),
+    webauthnLoginBegin: vi.fn(),
+    webauthnLoginFinish: vi.fn(),
+    authCheck: vi.fn(),
+    isWebAuthnSupported: vi.fn(),
+    prepareGetOptions: vi.fn(),
+    credentialsGet: vi.fn()
+}));
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+
+vi.mock('$lib/api/client', () => ({
+    auth: {
+        webauthnAvailable: mocks.webauthnAvailable,
+        webauthnLoginBegin: mocks.webauthnLoginBegin,
+        webauthnLoginFinish: mocks.webauthnLoginFinish,
+        login: vi.fn(),
+        setup: vi.fn()
+    },
+    ApiError: class ApiError extends Error {
+        status: number;
+        constructor(status: number, message: string) {
+            super(message);
+            this.name = 'ApiError';
+            this.status = status;
+        }
+    }
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+    authStore: { setupRequired: false, check: mocks.authCheck, login: vi.fn(), setup: vi.fn() }
+}));
+
+vi.mock('$lib/utils/webauthn', () => ({
+    isWebAuthnSupported: mocks.isWebAuthnSupported,
+    prepareGetOptions: mocks.prepareGetOptions
+}));
+
+const fakeBeginResponse = {
+    options: { publicKey: { challenge: 'abc123', timeout: 60000 } },
+    sessionId: 'test-session-id'
+};
+
+const fakeCredential = {
+    id: 'cred-abc',
+    type: 'public-key',
+    rawId: new ArrayBuffer(8)
+} as unknown as PublicKeyCredential;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isWebAuthnSupported.mockReturnValue(true);
+    mocks.prepareGetOptions.mockImplementation((opts: unknown) => opts);
+    mocks.webauthnAvailable.mockResolvedValue({ available: false });
+    mocks.webauthnLoginBegin.mockResolvedValue(fakeBeginResponse);
+    mocks.credentialsGet.mockResolvedValue(null);
+    mocks.webauthnLoginFinish.mockResolvedValue(undefined);
+    mocks.authCheck.mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, 'credentials', {
+        value: { get: mocks.credentialsGet },
+        configurable: true,
+        writable: true
+    });
+    Object.defineProperty(window, 'PublicKeyCredential', {
+        value: { isConditionalMediationAvailable: vi.fn().mockResolvedValue(false) },
+        configurable: true,
+        writable: true
+    });
+});
+
+describe('Login page — passkey auto-trigger', () => {
+    it('does not check for passkeys or render the passkey button when WebAuthn is unsupported', async () => {
+        mocks.isWebAuthnSupported.mockReturnValue(false);
+        render(LoginPage);
+        await new Promise((r) => setTimeout(r, 20));
+        expect(mocks.webauthnAvailable).not.toHaveBeenCalled();
+        expect(screen.queryByRole('button', { name: /sign in with a passkey/i })).toBeNull();
+    });
+
+    it('does not auto-trigger or show the passkey button when no passkeys are registered', async () => {
+        mocks.webauthnAvailable.mockResolvedValue({ available: false });
+        render(LoginPage);
+        await waitFor(() => expect(mocks.webauthnAvailable).toHaveBeenCalled());
+        expect(screen.queryByRole('button', { name: /sign in with a passkey/i })).toBeNull();
+        expect(mocks.webauthnLoginBegin).not.toHaveBeenCalled();
+    });
+
+    it('immediately calls credentials.get without conditional mediation when passkeys are available', async () => {
+        mocks.webauthnAvailable.mockResolvedValue({ available: true });
+        mocks.credentialsGet.mockReturnValue(new Promise(() => {}));
+        render(LoginPage);
+        await waitFor(() => expect(mocks.credentialsGet).toHaveBeenCalled());
+        const callArg = mocks.credentialsGet.mock.calls[0][0] as CredentialRequestOptions;
+        expect(callArg.mediation).toBeUndefined();
+        expect(callArg.publicKey).toBeDefined();
+    });
+
+    it('shows the passkey button in a disabled loading state while the auto-trigger is pending', async () => {
+        mocks.webauthnAvailable.mockResolvedValue({ available: true });
+        mocks.credentialsGet.mockReturnValue(new Promise(() => {}));
+        render(LoginPage);
+        await waitFor(() => expect(mocks.credentialsGet).toHaveBeenCalled());
+        const btn = screen.getByRole('button', {
+            name: /sign in with a passkey/i
+        }) as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+    });
+
+    it('completes login and navigates to "/" when auto-triggered passkey authentication succeeds', async () => {
+        mocks.webauthnAvailable.mockResolvedValue({ available: true });
+        mocks.credentialsGet.mockResolvedValue(fakeCredential);
+        render(LoginPage);
+        await waitFor(() => expect(goto).toHaveBeenCalledWith('/'));
+        expect(mocks.webauthnLoginFinish).toHaveBeenCalledWith(
+            fakeBeginResponse.sessionId,
+            fakeCredential
+        );
+        expect(mocks.authCheck).toHaveBeenCalled();
+    });
+
+    it('shows no error and re-enables the button when the auto-triggered prompt is dismissed', async () => {
+        mocks.webauthnAvailable.mockResolvedValue({ available: true });
+        const cancelled = Object.assign(new Error('Not allowed'), { name: 'NotAllowedError' });
+        mocks.credentialsGet.mockRejectedValue(cancelled);
+        render(LoginPage);
+        await waitFor(() => {
+            expect(
+                (screen.getByRole('button', { name: /sign in with a passkey/i }) as HTMLButtonElement).disabled
+            ).toBe(false);
+        });
+        expect(screen.queryByRole('alert')).toBeNull();
+    });
+
+    it('shows an error message when the auto-trigger finish step fails with an API error', async () => {
+        mocks.webauthnAvailable.mockResolvedValue({ available: true });
+        mocks.credentialsGet.mockResolvedValue(fakeCredential);
+        mocks.webauthnLoginFinish.mockRejectedValue(new ApiError(500, 'Server error'));
+        render(LoginPage);
+        await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+        expect(screen.getByRole('alert').textContent).toContain('Server error');
+    });
+
+    it('shows a cancellation error when the user dismisses the manual passkey prompt', async () => {
+        mocks.webauthnAvailable.mockResolvedValue({ available: true });
+        const cancelled = Object.assign(new Error('Not allowed'), { name: 'NotAllowedError' });
+        mocks.credentialsGet.mockRejectedValue(cancelled);
+        render(LoginPage);
+
+        // Wait for auto-trigger to fail silently and re-enable the button
+        await waitFor(() => {
+            expect(
+                (screen.getByRole('button', { name: /sign in with a passkey/i }) as HTMLButtonElement).disabled
+            ).toBe(false);
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: /sign in with a passkey/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert').textContent).toContain(
+                'Passkey authentication was cancelled'
+            );
+        });
+    });
+});


### PR DESCRIPTION
Fixes #570

## Description

Passkeys login flow will now auto-start if available.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [x] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags / AutoTagger
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have run `make pr-check` and all relevant checks passed
    - Backend changes: `make lint`, `make test`, and `make test-race`
    - Frontend changes: `make frontend-check`, `make frontend-test-unit`, `make frontend-test-integration-auto`, and `make frontend-test-e2e-smoke-auto`
- [ ] If I needed Go lint autofixes before rerunning checks, I used `make pr-check-fix`

### Frontend PR Checks

- [x] If this PR changes frontend flows outside the smoke subset, I also ran broader or focused browser coverage such as `make frontend-test-e2e`, `make frontend-test-e2e-file <spec>`, or `make frontend-test-e2e-module <tag>`
- [ ] If this PR intentionally changes UI presentation, I ran `make frontend-test-e2e-visual`
- [ ] If this PR intentionally changes committed visual baselines, I ran `make frontend-test-e2e-visual-baselines` and included the updated artifacts
- [ ] If this PR refreshes documentation imagery, I ran `make frontend-test-e2e-docs-screenshots` and included the updated `docs/images/` assets
- [ ] If this PR affects performance-sensitive frontend flows, I ran the relevant `make frontend-test-e2e-performance*` lane

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
