### PR TITLE
fix(ui): when exiting the lightbox you should be centered on the item you were on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - build(deps): bump node from 22-bookworm-slim to 26-bookworm-slim ([#569](https://github.com/djryanj/media-viewer/pull/569))
 - chore: clean up old legacy vanilla JS code ([#572](https://github.com/djryanj/media-viewer/issues/572))
-- fix(ui): passkey authorization flow will auto-trigger if available. ([#570](https://github.com/djryanj/media-viewer/issues/570))
+- fix(ui): passkey authorization flow will auto-trigger if available ([#570](https://github.com/djryanj/media-viewer/issues/570))
+- fix(ui): when exiting the lightbox, the gallery view should be centered on the last item viewed. [#571](https://github.com/djryanj/media-viewer/issues/571)
 
 ## [0.19.0] - 06-15-2026
 

--- a/frontend/src/lib/components/lightbox/Lightbox.svelte
+++ b/frontend/src/lib/components/lightbox/Lightbox.svelte
@@ -453,6 +453,22 @@
         });
     }
 
+    // ── Scroll-to-item on close ──────────────────────────────────────────────
+    let lastViewedPath: string | null = null;
+
+    $effect(() => {
+        if (lightboxStore.item) lastViewedPath = lightboxStore.item.path;
+    });
+
+    $effect(() => {
+        if (!lightboxStore.open && lastViewedPath) {
+            const el = document.querySelector<HTMLElement>(
+                `[data-path="${CSS.escape(lastViewedPath)}"]`
+            );
+            el?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        }
+    });
+
     // ── Preloading ───────────────────────────────────────────────────────────
     // Hold strong refs so the browser doesn't GC the objects before caching.
     const preloadCache = new Map<string, HTMLImageElement | HTMLVideoElement>();

--- a/frontend/src/tests/components/Lightbox.test.ts
+++ b/frontend/src/tests/components/Lightbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import Lightbox from '$lib/components/lightbox/Lightbox.svelte';
@@ -253,5 +253,119 @@ describe('Lightbox — collections panel', () => {
         expect(
             screen.getByRole('button', { name: 'Collections' }).getAttribute('aria-pressed')
         ).toBe('false');
+    });
+});
+
+describe('Lightbox — scroll to item on close', () => {
+    let scrollIntoView1: ReturnType<typeof vi.fn>;
+    let el1: HTMLElement;
+
+    beforeEach(() => {
+        lightboxStore.close();
+        vi.clearAllMocks();
+
+        scrollIntoView1 = vi.fn();
+        el1 = document.createElement('div');
+        el1.dataset.path = img1.path;
+        el1.scrollIntoView = scrollIntoView1 as unknown as typeof el1.scrollIntoView;
+        document.body.appendChild(el1);
+    });
+
+    afterEach(() => {
+        el1.remove();
+    });
+
+    it('calls scrollIntoView on the matching gallery element when the lightbox closes', async () => {
+        render(Lightbox);
+        lightboxStore.show(img1, twoItems);
+        await waitFor(() => screen.getByRole('dialog'));
+
+        lightboxStore.close();
+        await tick();
+
+        expect(scrollIntoView1).toHaveBeenCalledOnce();
+    });
+
+    it('passes { block: "nearest", inline: "nearest" } to scrollIntoView', async () => {
+        render(Lightbox);
+        lightboxStore.show(img1, twoItems);
+        await waitFor(() => screen.getByRole('dialog'));
+
+        lightboxStore.close();
+        await tick();
+
+        expect(scrollIntoView1).toHaveBeenCalledWith({ block: 'nearest', inline: 'nearest' });
+    });
+
+    it('scrolls to the last navigated item, not the originally opened one', async () => {
+        const scrollIntoView2 = vi.fn();
+        const el2 = document.createElement('div');
+        el2.dataset.path = img2.path;
+        el2.scrollIntoView = scrollIntoView2 as unknown as typeof el2.scrollIntoView;
+        document.body.appendChild(el2);
+
+        render(Lightbox);
+        lightboxStore.show(img1, twoItems);
+        await waitFor(() => screen.getByRole('dialog'));
+
+        lightboxStore.next(); // navigate to img2
+        await tick();
+
+        lightboxStore.close();
+        await tick();
+
+        expect(scrollIntoView2).toHaveBeenCalledOnce();
+        expect(scrollIntoView1).not.toHaveBeenCalled();
+
+        el2.remove();
+    });
+
+    it('does nothing when no gallery element with a matching data-path exists', async () => {
+        el1.remove(); // no element in the DOM for img1
+
+        render(Lightbox);
+        lightboxStore.show(img1, twoItems);
+        await waitFor(() => screen.getByRole('dialog'));
+
+        // Should not throw
+        expect(() => lightboxStore.close()).not.toThrow();
+        await tick();
+    });
+
+    it('does not call scrollIntoView while the lightbox is open', async () => {
+        render(Lightbox);
+        lightboxStore.show(img1, twoItems);
+        await waitFor(() => screen.getByRole('dialog'));
+
+        lightboxStore.next();
+        await tick();
+
+        expect(scrollIntoView1).not.toHaveBeenCalled();
+    });
+
+    it('scrolls to the correct item across multiple open/close cycles', async () => {
+        const scrollIntoView2 = vi.fn();
+        const el2 = document.createElement('div');
+        el2.dataset.path = img2.path;
+        el2.scrollIntoView = scrollIntoView2 as unknown as typeof el2.scrollIntoView;
+        document.body.appendChild(el2);
+
+        render(Lightbox);
+
+        lightboxStore.show(img1, twoItems);
+        await waitFor(() => screen.getByRole('dialog'));
+        lightboxStore.close();
+        await tick();
+        expect(scrollIntoView1).toHaveBeenCalledTimes(1);
+        expect(scrollIntoView2).not.toHaveBeenCalled();
+
+        lightboxStore.show(img2, twoItems);
+        await waitFor(() => screen.getByRole('dialog'));
+        lightboxStore.close();
+        await tick();
+        expect(scrollIntoView2).toHaveBeenCalledTimes(1);
+        expect(scrollIntoView1).toHaveBeenCalledTimes(1); // still only once from first cycle
+
+        el2.remove();
     });
 });


### PR DESCRIPTION
Fixes #571

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [x] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags / AutoTagger
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have run `make pr-check` and all relevant checks passed
    - Backend changes: `make lint`, `make test`, and `make test-race`
    - Frontend changes: `make frontend-check`, `make frontend-test-unit`, `make frontend-test-integration-auto`, and `make frontend-test-e2e-smoke-auto`
- [ ] If I needed Go lint autofixes before rerunning checks, I used `make pr-check-fix`

### Frontend PR Checks

- [x] If this PR changes frontend flows outside the smoke subset, I also ran broader or focused browser coverage such as `make frontend-test-e2e`, `make frontend-test-e2e-file <spec>`, or `make frontend-test-e2e-module <tag>`
- [x] If this PR intentionally changes UI presentation, I ran `make frontend-test-e2e-visual`
- [ ] If this PR intentionally changes committed visual baselines, I ran `make frontend-test-e2e-visual-baselines` and included the updated artifacts
- [ ] If this PR refreshes documentation imagery, I ran `make frontend-test-e2e-docs-screenshots` and included the updated `docs/images/` assets
- [ ] If this PR affects performance-sensitive frontend flows, I ran the relevant `make frontend-test-e2e-performance*` lane

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
