### PR TITLE
fix(ui): the status footer showed 2 "v"'s in the version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - Unreleased
+
+- fix(ui): there are 2 "s"'s in the version display ([#577](https://github.com/djryanj/media-viewer/issues/577))
+
 ## [0.19.1] - 06-18-2026
 
 - build(deps): bump node from 22-bookworm-slim to 26-bookworm-slim ([#569](https://github.com/djryanj/media-viewer/pull/569))

--- a/frontend/src/lib/components/layout/StatusFooter.svelte
+++ b/frontend/src/lib/components/layout/StatusFooter.svelte
@@ -9,6 +9,13 @@
     );
 
     let buildInfo = $state<BuildInfo | null>(null);
+    const displayVersion = $derived(
+        buildInfo
+            ? /^\d/.test(buildInfo.version)
+                ? `v${buildInfo.version}`
+                : buildInfo.version
+            : null
+    );
     let status = $state<SystemStatus | null>(null);
     let pollTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -108,8 +115,8 @@
 
     <!-- Right: version -->
     <span class="right">
-        {#if buildInfo}
-            v{buildInfo.version}
+        {#if displayVersion}
+            {displayVersion}
         {/if}
     </span>
 </footer>

--- a/frontend/src/tests/components/StatusFooter.test.ts
+++ b/frontend/src/tests/components/StatusFooter.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import StatusFooter from '$lib/components/layout/StatusFooter.svelte';
+import type { SystemStatus } from '$lib/api/types';
+
+const mocks = vi.hoisted(() => ({
+    versionGet: vi.fn(),
+    systemStatus: vi.fn()
+}));
+
+vi.mock('$lib/api/client', () => ({
+    version: { get: mocks.versionGet },
+    system: { status: mocks.systemStatus }
+}));
+
+const galleryState = vi.hoisted(() => ({ loading: false, totalItems: 0 }));
+
+vi.mock('$lib/stores/gallery.svelte', () => ({
+    galleryStore: galleryState
+}));
+
+function makeStatus(overrides: Partial<SystemStatus> = {}): SystemStatus {
+    const idle = {
+        summary: { enabled: true, running: false, state: 'idle' },
+        metrics: { processedItems: 0 }
+    };
+    return {
+        updatedAt: '2024-01-01T00:00:00Z',
+        library: {
+            totalFiles: 0,
+            totalImages: 0,
+            totalVideos: 0,
+            totalFolders: 0,
+            totalPlaylists: 0,
+            totalTags: 0,
+            totalFavorites: 0,
+            thumbnailCacheFiles: 0,
+            thumbnailCacheBytes: 0,
+            transcodeCacheFiles: 0,
+            transcodeCacheBytes: 0,
+            lastIndexed: ''
+        },
+        indexer: idle,
+        thumbnails: idle,
+        autotagger: idle,
+        ...overrides
+    };
+}
+
+beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    vi.clearAllMocks();
+    galleryState.loading = false;
+    galleryState.totalItems = 0;
+    mocks.versionGet.mockResolvedValue(null);
+    mocks.systemStatus.mockResolvedValue(makeStatus());
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+// ── Version display ───────────────────────────────────────────────────────────
+
+describe('StatusFooter — version display', () => {
+    it('displays version unchanged when it already starts with "v"', async () => {
+        mocks.versionGet.mockResolvedValue({
+            version: 'v0.19.0',
+            commit: 'abc',
+            buildTime: '',
+            goVersion: '',
+            os: '',
+            arch: ''
+        });
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('v0.19.0')).toBeTruthy());
+    });
+
+    it('prepends "v" when version is a bare semver without prefix', async () => {
+        mocks.versionGet.mockResolvedValue({
+            version: '0.19.0',
+            commit: 'abc',
+            buildTime: '',
+            goVersion: '',
+            os: '',
+            arch: ''
+        });
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('v0.19.0')).toBeTruthy());
+    });
+
+    it('displays "dev" without adding "v" prefix', async () => {
+        mocks.versionGet.mockResolvedValue({
+            version: 'dev',
+            commit: 'abc',
+            buildTime: '',
+            goVersion: '',
+            os: '',
+            arch: ''
+        });
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('dev')).toBeTruthy());
+    });
+
+    it('shows nothing in the version slot while buildInfo has not loaded', () => {
+        mocks.versionGet.mockReturnValue(new Promise(() => {})); // never resolves
+        const { container } = render(StatusFooter);
+        const right = container.querySelector('.right');
+        expect(right?.textContent?.trim()).toBe('');
+    });
+});
+
+// ── Item count ────────────────────────────────────────────────────────────────
+
+describe('StatusFooter — item count', () => {
+    it('shows "N items" when gallery has items and is not loading', async () => {
+        galleryState.totalItems = 42;
+        galleryState.loading = false;
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('42 items')).toBeTruthy());
+    });
+
+    it('uses singular "item" when there is exactly one item', async () => {
+        galleryState.totalItems = 1;
+        galleryState.loading = false;
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('1 item')).toBeTruthy());
+    });
+
+    it('shows nothing when the gallery is loading', () => {
+        galleryState.totalItems = 100;
+        galleryState.loading = true;
+        const { container } = render(StatusFooter);
+        const left = container.querySelector('.left');
+        expect(left?.textContent?.trim()).toBe('');
+    });
+
+    it('shows nothing when totalItems is 0', () => {
+        galleryState.totalItems = 0;
+        galleryState.loading = false;
+        const { container } = render(StatusFooter);
+        const left = container.querySelector('.left');
+        expect(left?.textContent?.trim()).toBe('');
+    });
+});
+
+// ── Worker status labels ──────────────────────────────────────────────────────
+
+describe('StatusFooter — worker labels', () => {
+    it('shows nothing in the centre when all workers are idle', async () => {
+        mocks.systemStatus.mockResolvedValue(makeStatus());
+        const { container } = render(StatusFooter);
+        await waitFor(() => expect(mocks.systemStatus).toHaveBeenCalled());
+        const centre = container.querySelector('.centre');
+        expect(centre?.textContent?.trim()).toBe('');
+    });
+
+    it('shows "Indexing" when indexer is running with no progress info', async () => {
+        mocks.systemStatus.mockResolvedValue(
+            makeStatus({
+                indexer: {
+                    summary: { enabled: true, running: true, state: 'running' },
+                    metrics: { processedItems: 0 }
+                }
+            })
+        );
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('Indexing')).toBeTruthy());
+    });
+
+    it('shows percentage when progressPercent is available', async () => {
+        mocks.systemStatus.mockResolvedValue(
+            makeStatus({
+                indexer: {
+                    summary: { enabled: true, running: true, state: 'running' },
+                    metrics: { processedItems: 50, progressPercent: 42.6 }
+                }
+            })
+        );
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('Indexing 43%')).toBeTruthy());
+    });
+
+    it('shows processed item count when progressPercent is absent', async () => {
+        mocks.systemStatus.mockResolvedValue(
+            makeStatus({
+                thumbnails: {
+                    summary: { enabled: true, running: true, state: 'running' },
+                    metrics: { processedItems: 10 }
+                }
+            })
+        );
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('Thumbnails (10 processed)')).toBeTruthy());
+    });
+
+    it('joins multiple active workers with " · "', async () => {
+        mocks.systemStatus.mockResolvedValue(
+            makeStatus({
+                indexer: {
+                    summary: { enabled: true, running: true, state: 'running' },
+                    metrics: { processedItems: 0 }
+                },
+                thumbnails: {
+                    summary: { enabled: true, running: true, state: 'running' },
+                    metrics: { processedItems: 0 }
+                }
+            })
+        );
+        render(StatusFooter);
+        await waitFor(() => expect(screen.getByText('Indexing · Thumbnails')).toBeTruthy());
+    });
+});
+
+// ── Window events ─────────────────────────────────────────────────────────────
+
+describe('StatusFooter — window events', () => {
+    it('dispatches "indexer:running" when any worker is active', async () => {
+        mocks.systemStatus.mockResolvedValue(
+            makeStatus({
+                indexer: {
+                    summary: { enabled: true, running: true, state: 'running' },
+                    metrics: { processedItems: 0 }
+                }
+            })
+        );
+        const handler = vi.fn();
+        window.addEventListener('indexer:running', handler);
+        render(StatusFooter);
+        await waitFor(() => expect(handler).toHaveBeenCalled());
+        window.removeEventListener('indexer:running', handler);
+    });
+
+    it('dispatches "indexer:complete" when workers transition from running to idle', async () => {
+        mocks.systemStatus
+            .mockResolvedValueOnce(
+                makeStatus({
+                    indexer: {
+                        summary: { enabled: true, running: true, state: 'running' },
+                        metrics: { processedItems: 0 }
+                    }
+                })
+            )
+            .mockResolvedValueOnce(makeStatus());
+
+        const completeHandler = vi.fn();
+        window.addEventListener('indexer:complete', completeHandler);
+
+        render(StatusFooter);
+        // Wait for the running state to register
+        await waitFor(() => expect(mocks.systemStatus).toHaveBeenCalledOnce());
+        // Advance 3 s to trigger the running-mode interval for the second poll
+        await vi.advanceTimersByTimeAsync(3001);
+        await waitFor(() => expect(completeHandler).toHaveBeenCalled());
+
+        window.removeEventListener('indexer:complete', completeHandler);
+    });
+});


### PR DESCRIPTION
## Description

The UI would occasionally show to "v"'s in the version string. This adds smart detection depending on the string and will show it correctly with 1 "v" in all cases.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [x] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags / AutoTagger
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have run `make pr-check` and all relevant checks passed
    - Backend changes: `make lint`, `make test`, and `make test-race`
    - Frontend changes: `make frontend-check`, `make frontend-test-unit`, `make frontend-test-integration-auto`, and `make frontend-test-e2e-smoke-auto`
- [ ] If I needed Go lint autofixes before rerunning checks, I used `make pr-check-fix`

### Frontend PR Checks

- [ ] If this PR changes frontend flows outside the smoke subset, I also ran broader or focused browser coverage such as `make frontend-test-e2e`, `make frontend-test-e2e-file <spec>`, or `make frontend-test-e2e-module <tag>`
- [ ] If this PR intentionally changes UI presentation, I ran `make frontend-test-e2e-visual`
- [ ] If this PR intentionally changes committed visual baselines, I ran `make frontend-test-e2e-visual-baselines` and included the updated artifacts
- [ ] If this PR refreshes documentation imagery, I ran `make frontend-test-e2e-docs-screenshots` and included the updated `docs/images/` assets
- [ ] If this PR affects performance-sensitive frontend flows, I ran the relevant `make frontend-test-e2e-performance*` lane

## Related Issues

<!-- Link related issues here -->

Closes #577 
Related to #

## Additional Notes

<!-- Any additional information -->
