### PR TITLE
fix(ui): add in a loading spinner and notification that a video is transcoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.19.2] - Unreleased
 
 - fix(ui): there are 2 "s"'s in the version display ([#577](https://github.com/djryanj/media-viewer/issues/577))
+- fix(ui): when loading a video that needs transcoding on the server, there was just a long pause rather than some kind of notification that it was loading. ([#578](https://github.com/djryanj/media-viewer/issues/578))
 
 ## [0.19.1] - 06-18-2026
 

--- a/frontend/src/lib/components/lightbox/VideoPlayer.svelte
+++ b/frontend/src/lib/components/lightbox/VideoPlayer.svelte
@@ -43,6 +43,8 @@
     let isDragging = $state(false);
     let isInteractingWithBar = $state(false);
     let hasError = $state(false);
+    let loading = $state(false);
+    let transcoding = $state(false);
 
     // ── Volume (persisted) ────────────────────────────────────────────────────
     let volume = $state(loadVolume());
@@ -102,6 +104,8 @@
 
         cleanupPrev();
         hasError = false;
+        loading = true;
+        transcoding = false;
 
         if (!videoEl) return;
 
@@ -118,6 +122,7 @@
         if (stale() || !videoEl) return;
 
         if (info?.needsTranscode) {
+            transcoding = true;
             if (Hls.isSupported()) {
                 await loadViaHls(p, id);
                 return;
@@ -486,6 +491,8 @@
 
     // ── Video event handlers ──────────────────────────────────────────────────
     function onPlay() {
+        loading = false;
+        transcoding = false;
         paused = false;
         scheduleHide();
         acquireWakeLock();
@@ -500,9 +507,15 @@
         if (!isDragging && videoEl) currentTime = videoEl.currentTime;
     }
     function onDurationChange() {
-        if (videoEl) duration = videoEl.duration;
+        if (videoEl) {
+            duration = videoEl.duration;
+            loading = false;
+            transcoding = false;
+        }
     }
     function onError() {
+        loading = false;
+        transcoding = false;
         hasError = true;
     }
     function onEndedHandler() {
@@ -555,6 +568,19 @@
 
     {#if hasError}
         <div class="vp-error">Failed to load video</div>
+    {/if}
+
+    {#if loading && !hasError}
+        <div
+            class="vp-loading"
+            aria-live="polite"
+            aria-label={transcoding ? 'Transcoding video' : 'Loading video'}
+        >
+            <div class="vp-spinner" aria-hidden="true"></div>
+            {#if transcoding}
+                <span class="vp-loading-label">Transcoding video…</span>
+            {/if}
+        </div>
     {/if}
 
     <!-- Clock overlay -->
@@ -801,6 +827,38 @@
         position: absolute;
         color: rgba(255, 255, 255, 0.7);
         font-size: 0.875rem;
+    }
+
+    .vp-loading {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        pointer-events: none;
+    }
+
+    .vp-spinner {
+        width: 36px;
+        height: 36px;
+        border: 3px solid rgba(255, 255, 255, 0.2);
+        border-top-color: rgba(255, 255, 255, 0.8);
+        border-radius: 50%;
+        animation: vp-spin 0.75s linear infinite;
+    }
+
+    .vp-loading-label {
+        font-size: 0.8125rem;
+        color: rgba(255, 255, 255, 0.65);
+        letter-spacing: 0.01em;
+    }
+
+    @keyframes vp-spin {
+        to {
+            transform: rotate(360deg);
+        }
     }
 
     /* Clock — centered at top, matching the Lightbox clock position */

--- a/frontend/src/tests/components/VideoPlayer.test.ts
+++ b/frontend/src/tests/components/VideoPlayer.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import VideoPlayer from '$lib/components/lightbox/VideoPlayer.svelte';
 
-// Mock hls.js — not needed for the ended-event path
+// Hls.isSupported is made configurable so tests can route through loadViaHls
+// (where the component awaits the HLS session fetch) instead of loadDirect
+// (where happy-dom fires durationchange synchronously on src assignment,
+// clearing loading state before we can assert on it).
+const hlsMocks = vi.hoisted(() => ({
+    isSupported: vi.fn(() => false)
+}));
+
 vi.mock('hls.js', () => ({
     default: class Hls {
         static isSupported() {
-            return false;
+            return hlsMocks.isSupported();
         }
         destroy() {}
     }
@@ -22,18 +30,25 @@ function mockStreamInfoFetch(response: object = {}) {
     });
 }
 
-describe('VideoPlayer', () => {
-    let restoreFetch: () => void;
+// Resolves stream-info immediately with `response`; stalls any subsequent fetch
+// (the HLS session endpoint) so the component stays suspended after it sets
+// `loading = true` and `transcoding = true`, letting us assert on those states.
+function mockStreamInfoThenStall(response: object) {
+    return vi.fn().mockImplementation((url: string) => {
+        if ((url as string).includes('/api/stream-info/')) {
+            return Promise.resolve({ ok: true, json: () => Promise.resolve(response) });
+        }
+        return new Promise(() => {});
+    });
+}
 
+describe('VideoPlayer', () => {
     beforeEach(() => {
-        const original = globalThis.fetch;
-        restoreFetch = () => {
-            globalThis.fetch = original;
-        };
+        hlsMocks.isSupported.mockReturnValue(false);
     });
 
     afterEach(() => {
-        restoreFetch();
+        vi.unstubAllGlobals();
         vi.clearAllMocks();
     });
 
@@ -92,5 +107,119 @@ describe('VideoPlayer', () => {
         });
 
         expect(() => video.dispatchEvent(new Event('ended'))).not.toThrow();
+    });
+});
+
+// ── Loading indicator ─────────────────────────────────────────────────────────
+//
+// happy-dom fires `durationchange` synchronously when video.src is assigned,
+// which would immediately clear `loading` before we can assert on it.  The
+// solution for tests that need the spinner to stay visible is to route the
+// component through loadViaHls (Hls.isSupported=true) where it awaits the HLS
+// session fetch — stalled by mockStreamInfoThenStall — keeping loading=true.
+
+describe('VideoPlayer — loading indicator', () => {
+    beforeEach(() => {
+        hlsMocks.isSupported.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it('shows a loading spinner immediately while the source is being fetched', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {}))); // never resolves
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        await waitFor(() => expect(container.querySelector('.vp-loading')).toBeTruthy());
+        expect(container.querySelector('.vp-spinner')).toBeTruthy();
+    });
+
+    it('does not show the "Transcoding video…" label while stream-info is still loading', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        await waitFor(() => expect(container.querySelector('.vp-loading')).toBeTruthy());
+        expect(container.querySelector('.vp-loading-label')).toBeNull();
+    });
+
+    it('shows "Transcoding video…" label after stream-info reports needsTranscode', async () => {
+        // isSupported=true routes into loadViaHls; the stalled session fetch keeps
+        // the component suspended with loading=true and transcoding=true.
+        hlsMocks.isSupported.mockReturnValue(true);
+        vi.stubGlobal('fetch', mockStreamInfoThenStall({ needsTranscode: true }));
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        await waitFor(() =>
+            expect(container.querySelector('.vp-loading-label')?.textContent).toContain(
+                'Transcoding'
+            )
+        );
+    });
+
+    it('does not show "Transcoding video…" when needsTranscode is false', async () => {
+        vi.stubGlobal('fetch', mockStreamInfoFetch({ needsTranscode: false }));
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        // Wait for stream-info to resolve; transcoding was never set so the label
+        // must never appear regardless of whether the spinner itself is still visible.
+        await vi.waitFor(() =>
+            expect(container.querySelector('video')!.src).toContain('/api/stream/')
+        );
+        expect(container.querySelector('.vp-loading-label')).toBeNull();
+    });
+
+    it('hides the spinner when the video fires a play event', async () => {
+        hlsMocks.isSupported.mockReturnValue(true);
+        vi.stubGlobal('fetch', mockStreamInfoThenStall({ needsTranscode: true }));
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        const video = container.querySelector('video')!;
+        await waitFor(() => expect(container.querySelector('.vp-loading')).toBeTruthy());
+
+        video.dispatchEvent(new Event('play'));
+        await tick();
+
+        expect(container.querySelector('.vp-loading')).toBeNull();
+    });
+
+    it('hides the spinner when the video fires a durationchange event', async () => {
+        hlsMocks.isSupported.mockReturnValue(true);
+        vi.stubGlobal('fetch', mockStreamInfoThenStall({ needsTranscode: true }));
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        const video = container.querySelector('video')!;
+        await waitFor(() => expect(container.querySelector('.vp-loading')).toBeTruthy());
+
+        video.dispatchEvent(new Event('durationchange'));
+        await tick();
+
+        expect(container.querySelector('.vp-loading')).toBeNull();
+    });
+
+    it('hides the spinner when the video encounters an error', async () => {
+        hlsMocks.isSupported.mockReturnValue(true);
+        vi.stubGlobal('fetch', mockStreamInfoThenStall({ needsTranscode: true }));
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        const video = container.querySelector('video')!;
+        await waitFor(() => expect(container.querySelector('.vp-loading')).toBeTruthy());
+
+        video.dispatchEvent(new Event('error'));
+        await tick();
+
+        expect(container.querySelector('.vp-loading')).toBeNull();
+    });
+
+    it('clears the transcoding label when the video starts playing', async () => {
+        hlsMocks.isSupported.mockReturnValue(true);
+        vi.stubGlobal('fetch', mockStreamInfoThenStall({ needsTranscode: true }));
+        const { container } = render(VideoPlayer, { props: { path: 'test.mp4', autoplay: false } });
+        const video = container.querySelector('video')!;
+        await waitFor(() =>
+            expect(container.querySelector('.vp-loading-label')?.textContent).toContain(
+                'Transcoding'
+            )
+        );
+
+        video.dispatchEvent(new Event('play'));
+        await tick();
+
+        expect(container.querySelector('.vp-loading')).toBeNull();
+        expect(container.querySelector('.vp-loading-label')).toBeNull();
     });
 });


### PR DESCRIPTION
Fixes #578

## Description

When loading a video and/or when that video is transcoding, no message is shown which seems like the UI is frozen. This adds a spinner and message when needed.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Changes that don't affect code meaning (formatting, etc)
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `build`: Changes that affect the build system or dependencies
- [ ] `breaking`: Breaking change (add `!` after type, e.g., `feat!:`)
- [ ] `release`: Release a new version

## Component

<!-- Which component does this PR affect? -->

- [ ] Database
- [x] Frontend/UI
- [ ] API/Handlers
- [ ] Media Processing (thumbnails, transcoding)
- [ ] Search/Indexing
- [ ] Tags / AutoTagger
- [ ] Favorites
- [ ] Docker
- [ ] Documentation
- [ ] Metrics/Monitoring
- [ ] Other: **\_**

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
    - Example: `feat(api): add video streaming endpoint`
    - Example: `fix(database): resolve connection timeout issue`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have run `make pr-check` and all relevant checks passed
    - Backend changes: `make lint`, `make test`, and `make test-race`
    - Frontend changes: `make frontend-check`, `make frontend-test-unit`, `make frontend-test-integration-auto`, and `make frontend-test-e2e-smoke-auto`
- [ ] If I needed Go lint autofixes before rerunning checks, I used `make pr-check-fix`

### Frontend PR Checks

- [x] If this PR changes frontend flows outside the smoke subset, I also ran broader or focused browser coverage such as `make frontend-test-e2e`, `make frontend-test-e2e-file <spec>`, or `make frontend-test-e2e-module <tag>`
- [ ] If this PR intentionally changes UI presentation, I ran `make frontend-test-e2e-visual`
- [ ] If this PR intentionally changes committed visual baselines, I ran `make frontend-test-e2e-visual-baselines` and included the updated artifacts
- [ ] If this PR refreshes documentation imagery, I ran `make frontend-test-e2e-docs-screenshots` and included the updated `docs/images/` assets
- [ ] If this PR affects performance-sensitive frontend flows, I ran the relevant `make frontend-test-e2e-performance*` lane

## Related Issues

<!-- Link related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Any additional information -->
